### PR TITLE
Update BM25 logic to be consistent with Lucene

### DIFF
--- a/extension/fts/fts_indexing.cpp
+++ b/extension/fts/fts_indexing.cpp
@@ -191,7 +191,7 @@ static string IndexingScript(ClientContext &context, QualifiedName &qname, const
                        term_tf.termid,
                        tf,
                        df,
-                       (log(((SELECT num_docs FROM %fts_schema%.stats) - df + 0.5) / (df + 0.5) + 1) * ((tf * (k + 1)/(tf + k * (1 - b + b * (len / (SELECT avgdl FROM %fts_schema%.stats))))))) AS subscore
+                       (log(((SELECT num_docs FROM %fts_schema%.stats) - df + 0.5) / (df + 0.5) + 1) * ((tf/(tf + k * (1 - b + b * (len / (SELECT avgdl FROM %fts_schema%.stats))))))) AS subscore
                 FROM term_tf,
 					 cdocs,
 					 %fts_schema%.docs AS docs,


### PR DESCRIPTION
Hi, I'm working with Professor Jimmy Lin, and I noticed that the BM25 logic used for FTS is different than the Lucene implementation shown in [this paper](https://cs.uwaterloo.ca/~jimmylin/publications/Kamphuis_etal_ECIR2020_preprint.pdf). Since Lucene is a very widely used search engine, perhaps it would be nice to align the logic?