### PR TITLE
Allow indexes to be updated using `CREATE TRIGGER`

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -29,3 +29,12 @@ jobs:
       duckdb_version: main
       ci_tools_version: main
       extension_name: fts
+
+  code-quality-check:
+    name: Code Quality Check
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main
+    with:
+      duckdb_version: main
+      ci_tools_version: main
+      extension_name: fts
+      format_checks: 'format;tidy'

--- a/src/fts_extension.cpp
+++ b/src/fts_extension.cpp
@@ -68,6 +68,7 @@ static void LoadInternal(ExtensionLoader &loader) {
       LogicalType::BOOLEAN;
   create_fts_index_func.named_parameters["lower"] = LogicalType::BOOLEAN;
   create_fts_index_func.named_parameters["overwrite"] = LogicalType::BOOLEAN;
+  create_fts_index_func.named_parameters["incremental"] = LogicalType::BOOLEAN;
 
   auto drop_fts_index_func = PragmaFunction::PragmaCall(
       "drop_fts_index", FTSIndexing::DropFTSIndexQuery, {LogicalType::VARCHAR});

--- a/src/fts_indexing.cpp
+++ b/src/fts_indexing.cpp
@@ -33,8 +33,8 @@ static string GetFTSSchemaName(const QualifiedName &qname) {
 static string GetFTSSchema(const QualifiedName &qname) {
   auto result = IsInvalidCatalog(qname.catalog)
                     ? string("")
-                    : qname.catalog.GetIdentifierName() + ".";
-  result += GetFTSSchemaName(qname);
+                    : SQLIdentifier::ToString(qname.catalog.GetIdentifierName()) + ".";
+  result += SQLIdentifier::ToString(GetFTSSchemaName(qname));
   return result;
 }
 
@@ -117,12 +117,13 @@ static string TokenizeMacroScript(const string &ignore, bool strip_accents,
   return "CREATE MACRO %fts_schema%.tokenize(s) AS " + expr + ";";
 }
 
-static string IndexTablesScript(const vector<string> &input_values) {
+static string IndexTablesScript(const string &input_id,
+                                const vector<string> &input_values) {
   // clang-format off
 	string result = R"(
         CREATE TABLE %fts_schema%.docs AS (
             SELECT rowid AS docid,
-                   "%input_id%" AS name
+                   %input_id% AS name
             FROM %input_table%
         );
 
@@ -192,9 +193,9 @@ static string IndexTablesScript(const vector<string> &input_values) {
 
 	// Each field gets its own tokenize sub-query; they are unioned to retain the source field.
 	string tokenize_field_query = R"(
-        SELECT unnest(%fts_schema%.tokenize(fts_ii."%input_value%")) AS w,
+        SELECT unnest(%fts_schema%.tokenize(fts_ii.%input_value%)) AS w,
                rowid AS docid,
-               (SELECT fieldid FROM %fts_schema%.fields WHERE field = '%input_value%') AS fieldid
+               (SELECT fieldid FROM %fts_schema%.fields WHERE field = %input_value_string%) AS fieldid
         FROM %input_table% AS fts_ii
     )";
   // clang-format on
@@ -202,16 +203,22 @@ static string IndexTablesScript(const vector<string> &input_values) {
   vector<string> field_values;
   vector<string> tokenize_fields;
   for (idx_t i = 0; i < input_values.size(); i++) {
-    field_values.push_back(
-        StringUtil::Format("(%i, '%s')", i, input_values[i]));
-    tokenize_fields.push_back(StringUtil::Replace(
-        tokenize_field_query, "%input_value%", input_values[i]));
+    field_values.push_back(StringUtil::Format(
+        "(%i, %s)", i, SQLString::ToString(input_values[i])));
+    auto query =
+        StringUtil::Replace(tokenize_field_query, "%input_value%",
+                            SQLIdentifier::ToString(input_values[i]));
+    query = StringUtil::Replace(query, "%input_value_string%",
+                                SQLString::ToString(input_values[i]));
+    tokenize_fields.push_back(query);
   }
   result = StringUtil::Replace(result, "%field_values%",
                                StringUtil::Join(field_values, ", "));
   result =
       StringUtil::Replace(result, "%union_fields_query%",
                           StringUtil::Join(tokenize_fields, " UNION ALL "));
+  result = StringUtil::Replace(result, "%input_id%",
+                               SQLIdentifier::ToString(input_id));
   return result;
 }
 
@@ -478,27 +485,23 @@ static string IndexingScript(ClientContext &context, QualifiedName &qname,
                              const string &ignore, bool strip_accents,
                              bool lower, bool incremental) {
   string result;
-  if (incremental) {
+  if (TableExists(context, qname) && SupportsFTSTriggers(context, qname)) {
     result += DropFTSTriggersScript(qname);
   }
   result += SchemaSetupScript();
   result += StopwordsScript(stopwords);
   result += TokenizeMacroScript(ignore, strip_accents, lower);
-  result += IndexTablesScript(input_values);
+  result += IndexTablesScript(input_id, input_values);
   result += MatchMacroScript();
   if (incremental) {
     result += InsertTriggerScript(qname, input_id, input_values);
   }
 
   string fts_schema = GetFTSSchema(qname);
-  string input_table = qname.catalog == INVALID_CATALOG
-                           ? ""
-                           : StringUtil::Format("%s.", qname.catalog);
-  input_table += StringUtil::Format("%s.%s", qname.schema, qname.name);
+  string input_table = GetQualifiedTableName(qname);
 
   result = StringUtil::Replace(result, "%fts_schema%", fts_schema);
   result = StringUtil::Replace(result, "%input_table%", input_table);
-  result = StringUtil::Replace(result, "%input_id%", input_id);
   result = StringUtil::Replace(result, "%stemmer%", stemmer);
   return result;
 }

--- a/src/fts_indexing.cpp
+++ b/src/fts_indexing.cpp
@@ -31,9 +31,10 @@ static string GetFTSSchemaName(const QualifiedName &qname) {
 }
 
 static string GetFTSSchema(const QualifiedName &qname) {
-  auto result = IsInvalidCatalog(qname.catalog)
-                    ? string("")
-                    : SQLIdentifier::ToString(qname.catalog.GetIdentifierName()) + ".";
+  auto result =
+      IsInvalidCatalog(qname.catalog)
+          ? string("")
+          : SQLIdentifier::ToString(qname.catalog.GetIdentifierName()) + ".";
   result += SQLIdentifier::ToString(GetFTSSchemaName(qname));
   return result;
 }
@@ -205,9 +206,8 @@ static string IndexTablesScript(const string &input_id,
   for (idx_t i = 0; i < input_values.size(); i++) {
     field_values.push_back(StringUtil::Format(
         "(%i, %s)", i, SQLString::ToString(input_values[i])));
-    auto query =
-        StringUtil::Replace(tokenize_field_query, "%input_value%",
-                            SQLIdentifier::ToString(input_values[i]));
+    auto query = StringUtil::Replace(tokenize_field_query, "%input_value%",
+                                     SQLIdentifier::ToString(input_values[i]));
     query = StringUtil::Replace(query, "%input_value_string%",
                                 SQLString::ToString(input_values[i]));
     tokenize_fields.push_back(query);

--- a/src/fts_indexing.cpp
+++ b/src/fts_indexing.cpp
@@ -4,9 +4,13 @@
 #include "duckdb/catalog/catalog_search_path.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/sql_identifier.hpp"
+#include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/parser/qualified_name.hpp"
+#include "duckdb/storage/storage_info.hpp"
+#include "duckdb/storage/storage_manager.hpp"
 
 namespace duckdb {
 
@@ -32,6 +36,40 @@ static string GetFTSSchema(const QualifiedName &qname) {
                     : qname.catalog.GetIdentifierName() + ".";
   result += GetFTSSchemaName(qname);
   return result;
+}
+
+static string GetQualifiedTableName(const QualifiedName &qname) {
+  vector<string> parts;
+  if (!IsInvalidCatalog(qname.catalog)) {
+    parts.push_back(SQLIdentifier::ToString(qname.catalog.GetIdentifierName()));
+  }
+  parts.push_back(SQLIdentifier::ToString(qname.schema.GetIdentifierName()));
+  parts.push_back(SQLIdentifier::ToString(qname.name.GetIdentifierName()));
+  return StringUtil::Join(parts, ".");
+}
+
+static vector<string> GetFTSTriggerNames(const QualifiedName &qname) {
+  auto prefix = StringUtil::Format("__fts_%s_ai_", GetFTSSchemaName(qname));
+  return {prefix + "00_docs", prefix + "10_dict_insert",
+          prefix + "20_terms", prefix + "30_dict_df", prefix + "40_stats"};
+}
+
+static bool TableExists(ClientContext &context, const QualifiedName &qname) {
+  return Catalog::GetEntry<TableCatalogEntry>(
+             context, qname.catalog, qname.schema, qname.name,
+             OnEntryNotFound::RETURN_NULL) != nullptr;
+}
+
+static bool SupportsFTSTriggers(ClientContext &context,
+                                const QualifiedName &qname) {
+  auto &catalog = Catalog::GetCatalog(context, qname.catalog);
+  auto &attached = catalog.GetAttached();
+  if (!attached.HasStorageManager()) {
+    return true;
+  }
+  auto &storage_manager = attached.GetStorageManager();
+  return storage_manager.InMemory() ||
+         storage_manager.GetStorageVersion() >= StorageVersion::V2_0_0;
 }
 
 // ---------------------------------------------------------------------------
@@ -247,6 +285,185 @@ static string MatchMacroScript() {
   // clang-format on
 }
 
+static string DropFTSTriggersScript(const QualifiedName &qname) {
+  vector<string> statements;
+  auto input_table = GetQualifiedTableName(qname);
+  for (auto &trigger_name : GetFTSTriggerNames(qname)) {
+    statements.push_back(StringUtil::Format("DROP TRIGGER IF EXISTS %s ON %s;",
+                                            SQLIdentifier::ToString(trigger_name),
+                                            input_table));
+  }
+  return StringUtil::Join(statements, "\n");
+}
+
+static string InsertTriggerScript(const QualifiedName &qname,
+                                  const string &input_id,
+                                  const vector<string> &input_values) {
+  // clang-format off
+	string docs_new_docs_cte = R"(
+        fts_new_docs AS (
+            SELECT COALESCE((SELECT max(docid) + 1 FROM %fts_schema%.docs), 0)
+                       + row_number() OVER (ORDER BY fts_new_rows.%input_id%) - 1 AS docid,
+                   fts_new_rows.%input_id% AS name,
+                   %input_value_select_list%
+            FROM fts_new_rows
+        )
+    )";
+
+	string token_new_docs_cte = R"(
+        fts_new_docs AS (
+            SELECT (SELECT max(docid) - (SELECT count(*) FROM fts_new_rows) + 1 FROM %fts_schema%.docs)
+                       + row_number() OVER (ORDER BY fts_new_rows.%input_id%) - 1 AS docid,
+                   fts_new_rows.%input_id% AS name,
+                   %input_value_select_list%
+            FROM fts_new_rows
+        )
+    )";
+
+	string tokenize_field_query = R"(
+        SELECT unnest(%fts_schema%.tokenize(fts_ii.%input_value%)) AS w,
+               fts_ii.docid AS docid,
+               (SELECT fieldid FROM %fts_schema%.fields WHERE field = %input_value_string%) AS fieldid
+        FROM fts_new_docs AS fts_ii
+    )";
+
+	string token_ctes = R"(
+        WITH %new_docs_cte%,
+        tokenized AS (
+            %union_fields_query%
+        ),
+        stemmed_stopped AS (
+            SELECT stem(t.w, '%stemmer%') AS term,
+                   t.docid AS docid,
+                   t.fieldid AS fieldid
+            FROM tokenized AS t
+            WHERE t.w NOT NULL
+              AND len(t.w) > 0
+              AND t.w NOT IN (SELECT sw FROM %fts_schema%.stopwords)
+        )
+    )";
+
+	string result = R"(
+        CREATE TRIGGER %trigger_00_docs% AFTER INSERT ON %input_table%
+        REFERENCING NEW TABLE AS fts_new_rows
+        FOR EACH STATEMENT
+            INSERT INTO %fts_schema%.docs (docid, name, len)
+            WITH %docs_new_docs_cte%,
+            tokenized AS (
+                %union_fields_query%
+            ),
+            stemmed_stopped AS (
+                SELECT stem(t.w, '%stemmer%') AS term,
+                       t.docid AS docid,
+                       t.fieldid AS fieldid
+                FROM tokenized AS t
+                WHERE t.w NOT NULL
+                  AND len(t.w) > 0
+                  AND t.w NOT IN (SELECT sw FROM %fts_schema%.stopwords)
+            ),
+            lengths AS (
+                SELECT docid, count(term) AS len
+                FROM stemmed_stopped
+                GROUP BY docid
+            )
+            SELECT nd.docid,
+                   nd.name,
+                   COALESCE(l.len, 0) AS len
+            FROM fts_new_docs AS nd
+            LEFT JOIN lengths AS l ON nd.docid = l.docid;
+
+        CREATE TRIGGER %trigger_10_dict_insert% AFTER INSERT ON %input_table%
+        REFERENCING NEW TABLE AS fts_new_rows
+        FOR EACH STATEMENT
+            INSERT INTO %fts_schema%.dict (termid, term, df)
+            %token_ctes%,
+            new_terms AS (
+                SELECT DISTINCT term
+                FROM stemmed_stopped
+                WHERE term NOT IN (SELECT term FROM %fts_schema%.dict)
+                ORDER BY term
+            )
+            SELECT (SELECT COALESCE(max(termid) + 1, 0) FROM %fts_schema%.dict) + row_number() OVER () - 1 AS termid,
+                   term,
+                   0 AS df
+            FROM new_terms;
+
+        CREATE TRIGGER %trigger_20_terms% AFTER INSERT ON %input_table%
+        REFERENCING NEW TABLE AS fts_new_rows
+        FOR EACH STATEMENT
+            INSERT INTO %fts_schema%.terms (docid, fieldid, termid)
+            %token_ctes%
+            SELECT ss.docid,
+                   ss.fieldid,
+                   d.termid
+            FROM stemmed_stopped AS ss
+            JOIN %fts_schema%.dict AS d ON ss.term = d.term;
+
+        CREATE TRIGGER %trigger_30_dict_df% AFTER INSERT ON %input_table%
+        REFERENCING NEW TABLE AS fts_new_rows
+        FOR EACH STATEMENT
+            UPDATE %fts_schema%.dict AS d
+            SET df = (
+                SELECT count(DISTINCT docid)
+                FROM %fts_schema%.terms AS t
+                WHERE d.termid = t.termid
+            );
+
+        CREATE TRIGGER %trigger_40_stats% AFTER INSERT ON %input_table%
+        REFERENCING NEW TABLE AS fts_new_rows
+        FOR EACH STATEMENT
+            UPDATE %fts_schema%.stats
+            SET num_docs = (SELECT COUNT(docid) FROM %fts_schema%.docs),
+                avgdl = (SELECT SUM(len) / COUNT(len) FROM %fts_schema%.docs);
+    )";
+  // clang-format on
+
+  vector<string> input_value_selects;
+  vector<string> tokenize_fields;
+  for (auto &input_value : input_values) {
+    input_value_selects.push_back(StringUtil::Format("fts_new_rows.%s AS %s",
+                                                     SQLIdentifier::ToString(input_value),
+                                                     SQLIdentifier::ToString(input_value)));
+    auto query = StringUtil::Replace(tokenize_field_query, "%input_value%",
+                                     SQLIdentifier::ToString(input_value));
+    query = StringUtil::Replace(query, "%input_value_string%",
+                                SQLString::ToString(input_value));
+    tokenize_fields.push_back(query);
+  }
+
+  docs_new_docs_cte =
+      StringUtil::Replace(docs_new_docs_cte, "%input_value_select_list%",
+                          StringUtil::Join(input_value_selects, ",\n                   "));
+  token_new_docs_cte =
+      StringUtil::Replace(token_new_docs_cte, "%input_value_select_list%",
+                          StringUtil::Join(input_value_selects, ",\n                   "));
+  token_ctes = StringUtil::Replace(token_ctes, "%new_docs_cte%", token_new_docs_cte);
+  token_ctes =
+      StringUtil::Replace(token_ctes, "%union_fields_query%",
+                          StringUtil::Join(tokenize_fields, " UNION ALL "));
+  result = StringUtil::Replace(result, "%docs_new_docs_cte%", docs_new_docs_cte);
+  result =
+      StringUtil::Replace(result, "%union_fields_query%",
+                          StringUtil::Join(tokenize_fields, " UNION ALL "));
+  result = StringUtil::Replace(result, "%token_ctes%", token_ctes);
+
+  auto trigger_names = GetFTSTriggerNames(qname);
+  result = StringUtil::Replace(result, "%trigger_00_docs%",
+                               SQLIdentifier::ToString(trigger_names[0]));
+  result = StringUtil::Replace(result, "%trigger_10_dict_insert%",
+                               SQLIdentifier::ToString(trigger_names[1]));
+  result = StringUtil::Replace(result, "%trigger_20_terms%",
+                               SQLIdentifier::ToString(trigger_names[2]));
+  result = StringUtil::Replace(result, "%trigger_30_dict_df%",
+                               SQLIdentifier::ToString(trigger_names[3]));
+  result = StringUtil::Replace(result, "%trigger_40_stats%",
+                               SQLIdentifier::ToString(trigger_names[4]));
+  result = StringUtil::Replace(result, "%input_table%", GetQualifiedTableName(qname));
+  result =
+      StringUtil::Replace(result, "%input_id%", SQLIdentifier::ToString(input_id));
+  return result;
+}
+
 // ---------------------------------------------------------------------------
 // Coordinator: assembles all parts and substitutes cross-cutting placeholders
 // ---------------------------------------------------------------------------
@@ -258,11 +475,17 @@ static string IndexingScript(ClientContext &context, QualifiedName &qname,
                              const string &ignore, bool strip_accents,
                              bool lower) {
   string result;
+  if (SupportsFTSTriggers(context, qname)) {
+    result += DropFTSTriggersScript(qname);
+  }
   result += SchemaSetupScript();
   result += StopwordsScript(stopwords);
   result += TokenizeMacroScript(ignore, strip_accents, lower);
   result += IndexTablesScript(input_values);
   result += MatchMacroScript();
+  if (SupportsFTSTriggers(context, qname)) {
+    result += InsertTriggerScript(qname, input_id, input_values);
+  }
 
   string fts_schema = GetFTSSchema(qname);
   string input_table = qname.catalog == INVALID_CATALOG
@@ -296,7 +519,13 @@ string FTSIndexing::DropFTSIndexQuery(ClientContext &context,
                            qname.name.GetIdentifierName());
   }
 
-  return StringUtil::Format("DROP SCHEMA %s CASCADE;", fts_schema);
+  string result;
+  if (TableExists(context, qname) && SupportsFTSTriggers(context, qname)) {
+    result += DropFTSTriggersScript(qname);
+    result += "\n";
+  }
+  result += StringUtil::Format("DROP SCHEMA %s CASCADE;", fts_schema);
+  return result;
 }
 
 string FTSIndexing::CreateFTSIndexQuery(ClientContext &context,

--- a/src/fts_indexing.cpp
+++ b/src/fts_indexing.cpp
@@ -476,9 +476,9 @@ static string IndexingScript(ClientContext &context, QualifiedName &qname,
                              const vector<string> &input_values,
                              const string &stemmer, const string &stopwords,
                              const string &ignore, bool strip_accents,
-                             bool lower) {
+                             bool lower, bool incremental) {
   string result;
-  if (SupportsFTSTriggers(context, qname)) {
+  if (incremental) {
     result += DropFTSTriggersScript(qname);
   }
   result += SchemaSetupScript();
@@ -486,7 +486,7 @@ static string IndexingScript(ClientContext &context, QualifiedName &qname,
   result += TokenizeMacroScript(ignore, strip_accents, lower);
   result += IndexTablesScript(input_values);
   result += MatchMacroScript();
-  if (SupportsFTSTriggers(context, qname)) {
+  if (incremental) {
     result += InsertTriggerScript(qname, input_id, input_values);
   }
 
@@ -559,6 +559,7 @@ string FTSIndexing::CreateFTSIndexQuery(ClientContext &context,
   const bool strip_accents = get_bool("strip_accents", true);
   const bool lower = get_bool("lower", true);
   const bool overwrite = get_bool("overwrite", false);
+  const bool incremental = get_bool("incremental", false);
 
   if (stopwords != "english" && stopwords != "none") {
     auto sw_qname = GetQualifiedName(context, stopwords);
@@ -606,9 +607,16 @@ string FTSIndexing::CreateFTSIndexQuery(ClientContext &context,
     throw InvalidInputException(
         "at least one column must be supplied for indexing!");
   }
+  if (incremental && !SupportsFTSTriggers(context, qname)) {
+    throw InvalidInputException(
+        "incremental FTS indexes require trigger support. Persistent DuckDB "
+        "databases must use storage version v2.0.0 or higher; reattach/create "
+        "the database with STORAGE_VERSION 'v2.0.0', or omit incremental=true "
+        "to create a rebuild-only FTS index.");
+  }
 
   return IndexingScript(context, qname, doc_id, doc_values, stemmer, stopwords,
-                        ignore, strip_accents, lower);
+                        ignore, strip_accents, lower, incremental);
 }
 
 } // namespace duckdb

--- a/src/fts_indexing.cpp
+++ b/src/fts_indexing.cpp
@@ -50,8 +50,8 @@ static string GetQualifiedTableName(const QualifiedName &qname) {
 
 static vector<string> GetFTSTriggerNames(const QualifiedName &qname) {
   auto prefix = StringUtil::Format("__fts_%s_ai_", GetFTSSchemaName(qname));
-  return {prefix + "00_docs", prefix + "10_dict_insert",
-          prefix + "20_terms", prefix + "30_dict_df", prefix + "40_stats"};
+  return {prefix + "00_docs", prefix + "10_dict_insert", prefix + "20_terms",
+          prefix + "30_dict_df", prefix + "40_stats"};
 }
 
 static bool TableExists(ClientContext &context, const QualifiedName &qname) {
@@ -289,9 +289,9 @@ static string DropFTSTriggersScript(const QualifiedName &qname) {
   vector<string> statements;
   auto input_table = GetQualifiedTableName(qname);
   for (auto &trigger_name : GetFTSTriggerNames(qname)) {
-    statements.push_back(StringUtil::Format("DROP TRIGGER IF EXISTS %s ON %s;",
-                                            SQLIdentifier::ToString(trigger_name),
-                                            input_table));
+    statements.push_back(
+        StringUtil::Format("DROP TRIGGER IF EXISTS %s ON %s;",
+                           SQLIdentifier::ToString(trigger_name), input_table));
   }
   return StringUtil::Join(statements, "\n");
 }
@@ -421,9 +421,9 @@ static string InsertTriggerScript(const QualifiedName &qname,
   vector<string> input_value_selects;
   vector<string> tokenize_fields;
   for (auto &input_value : input_values) {
-    input_value_selects.push_back(StringUtil::Format("fts_new_rows.%s AS %s",
-                                                     SQLIdentifier::ToString(input_value),
-                                                     SQLIdentifier::ToString(input_value)));
+    input_value_selects.push_back(StringUtil::Format(
+        "fts_new_rows.%s AS %s", SQLIdentifier::ToString(input_value),
+        SQLIdentifier::ToString(input_value)));
     auto query = StringUtil::Replace(tokenize_field_query, "%input_value%",
                                      SQLIdentifier::ToString(input_value));
     query = StringUtil::Replace(query, "%input_value_string%",
@@ -431,17 +431,19 @@ static string InsertTriggerScript(const QualifiedName &qname,
     tokenize_fields.push_back(query);
   }
 
-  docs_new_docs_cte =
-      StringUtil::Replace(docs_new_docs_cte, "%input_value_select_list%",
-                          StringUtil::Join(input_value_selects, ",\n                   "));
-  token_new_docs_cte =
-      StringUtil::Replace(token_new_docs_cte, "%input_value_select_list%",
-                          StringUtil::Join(input_value_selects, ",\n                   "));
-  token_ctes = StringUtil::Replace(token_ctes, "%new_docs_cte%", token_new_docs_cte);
+  docs_new_docs_cte = StringUtil::Replace(
+      docs_new_docs_cte, "%input_value_select_list%",
+      StringUtil::Join(input_value_selects, ",\n                   "));
+  token_new_docs_cte = StringUtil::Replace(
+      token_new_docs_cte, "%input_value_select_list%",
+      StringUtil::Join(input_value_selects, ",\n                   "));
+  token_ctes =
+      StringUtil::Replace(token_ctes, "%new_docs_cte%", token_new_docs_cte);
   token_ctes =
       StringUtil::Replace(token_ctes, "%union_fields_query%",
                           StringUtil::Join(tokenize_fields, " UNION ALL "));
-  result = StringUtil::Replace(result, "%docs_new_docs_cte%", docs_new_docs_cte);
+  result =
+      StringUtil::Replace(result, "%docs_new_docs_cte%", docs_new_docs_cte);
   result =
       StringUtil::Replace(result, "%union_fields_query%",
                           StringUtil::Join(tokenize_fields, " UNION ALL "));
@@ -458,9 +460,10 @@ static string InsertTriggerScript(const QualifiedName &qname,
                                SQLIdentifier::ToString(trigger_names[3]));
   result = StringUtil::Replace(result, "%trigger_40_stats%",
                                SQLIdentifier::ToString(trigger_names[4]));
-  result = StringUtil::Replace(result, "%input_table%", GetQualifiedTableName(qname));
-  result =
-      StringUtil::Replace(result, "%input_id%", SQLIdentifier::ToString(input_id));
+  result = StringUtil::Replace(result, "%input_table%",
+                               GetQualifiedTableName(qname));
+  result = StringUtil::Replace(result, "%input_id%",
+                               SQLIdentifier::ToString(input_id));
   return result;
 }
 

--- a/test/sql/fts/test_fts_attach.test
+++ b/test/sql/fts/test_fts_attach.test
@@ -19,6 +19,11 @@ CREATE TABLE search_con.main.my_table AS SELECT 1 AS CustomerId, 'hans' as Custo
 statement ok
 PRAGMA create_fts_index(search_con.main.my_table, 'CustomerId', 'CustomerName')
 
+query I
+SELECT count(*) FROM duckdb_triggers() WHERE database_name = 'search_con' AND trigger_name LIKE '__fts_%'
+----
+0
+
 statement ok
 SELECT search_con.fts_main_my_table.match_bm25(1, 'han')
 

--- a/test/sql/fts/test_identifier_quoting.test
+++ b/test/sql/fts/test_identifier_quoting.test
@@ -1,0 +1,54 @@
+# name: test/sql/fts/test_identifier_quoting.test
+# description: Test FTS indexing with quoted table and column identifiers
+# group: [fts]
+
+require fts
+
+require skip_reload
+
+require no_alternative_verify
+
+# Quoted table names should be valid FTS input table names.
+statement ok
+CREATE TABLE "my docs"(id VARCHAR, body VARCHAR)
+
+statement ok
+INSERT INTO "my docs" VALUES ('doc1', 'quacking')
+
+statement ok
+PRAGMA create_fts_index('"my docs"', 'id', 'body', stemmer='porter', stopwords='none', incremental=true)
+
+query II
+SELECT name, len FROM "fts_main_my docs".docs
+----
+doc1	1
+
+# Indexed column names containing quotes should be escaped when building the
+# initial index SQL.
+statement ok
+CREATE TABLE quote_col(id VARCHAR, "bo""dy" VARCHAR)
+
+statement ok
+INSERT INTO quote_col VALUES ('doc1', 'quacking')
+
+statement ok
+PRAGMA create_fts_index('quote_col', 'id', 'bo"dy', stemmer='porter', stopwords='none', incremental=true)
+
+query II
+SELECT fieldid, field FROM fts_main_quote_col.fields
+----
+0	bo"dy
+
+statement ok
+CREATE TABLE single_quote_col(id VARCHAR, "bo'dy" VARCHAR)
+
+statement ok
+INSERT INTO single_quote_col VALUES ('doc1', 'quacking')
+
+statement ok
+PRAGMA create_fts_index('single_quote_col', 'id', 'bo''dy', stemmer='porter', stopwords='none', incremental=true)
+
+query II
+SELECT fieldid, field FROM fts_main_single_quote_col.fields
+----
+0	bo'dy

--- a/test/sql/fts/test_incremental_insert.test
+++ b/test/sql/fts/test_incremental_insert.test
@@ -9,13 +9,33 @@ require fts
 require no_alternative_verify
 
 statement ok
+CREATE TABLE static_docs (id VARCHAR, body VARCHAR)
+
+statement ok
+INSERT INTO static_docs VALUES ('doc1', 'quacking')
+
+statement ok
+PRAGMA create_fts_index('static_docs', 'id', 'body', stemmer='porter', stopwords='none')
+
+statement ok
+INSERT INTO static_docs VALUES ('doc2', 'barking')
+
+query I
+SELECT count(*) FROM fts_main_static_docs.docs
+----
+1
+
+statement ok
+PRAGMA drop_fts_index('static_docs')
+
+statement ok
 CREATE TABLE docs (id VARCHAR, body VARCHAR)
 
 statement ok
 INSERT INTO docs VALUES ('doc1', 'quacking quacking quacking'), ('doc2', 'barking barking barking barking')
 
 statement ok
-PRAGMA create_fts_index('docs', 'id', 'body', stemmer='porter', stopwords='none')
+PRAGMA create_fts_index('docs', 'id', 'body', stemmer='porter', stopwords='none', incremental=true)
 
 # baseline: two docs with porter-stemmed terms
 query III
@@ -134,7 +154,7 @@ SELECT count(*) FROM duckdb_schemas() WHERE schema_name = 'fts_main_docs'
 0
 
 statement ok
-PRAGMA create_fts_index('docs', 'id', 'body', stemmer='porter', stopwords='none')
+PRAGMA create_fts_index('docs', 'id', 'body', stemmer='porter', stopwords='none', incremental=true)
 
 # doc4 is now in the index (full rebuild)
 query I
@@ -144,7 +164,7 @@ SELECT count(*) FROM fts_main_docs.docs
 
 # overwrite drops the old trigger and recreates it; insert after overwrite still updates index
 statement ok
-PRAGMA create_fts_index('docs', 'id', 'body', stemmer='porter', stopwords='none', overwrite=true)
+PRAGMA create_fts_index('docs', 'id', 'body', stemmer='porter', stopwords='none', overwrite=true, incremental=true)
 
 statement ok
 INSERT INTO docs VALUES ('doc5', 'hissing hissing hissing hissing hissing')

--- a/test/sql/fts/test_incremental_insert.test
+++ b/test/sql/fts/test_incremental_insert.test
@@ -1,0 +1,155 @@
+# name: test/sql/fts/test_incremental_insert.test
+# description: Test that inserting into an indexed table updates docs, dict, terms, and stats
+# group: [fts]
+
+require skip_reload
+
+require fts
+
+require no_alternative_verify
+
+statement ok
+CREATE TABLE docs (id VARCHAR, body VARCHAR)
+
+statement ok
+INSERT INTO docs VALUES ('doc1', 'quacking quacking quacking'), ('doc2', 'barking barking barking barking')
+
+statement ok
+PRAGMA create_fts_index('docs', 'id', 'body', stemmer='porter', stopwords='none')
+
+# baseline: two docs with porter-stemmed terms
+query III
+SELECT name, docid, len FROM fts_main_docs.docs
+----
+doc1	0	3
+doc2	1	4
+
+query II
+SELECT term, df FROM fts_main_docs.dict ORDER BY term
+----
+bark	1
+quack	1
+
+# insert a new document that shares 'bark' with doc2
+statement ok
+INSERT INTO docs VALUES ('doc3', 'barking meowing meowing')
+
+# new doc appears in docs with correct len
+query III rowsort
+SELECT name, docid, len FROM fts_main_docs.docs
+----
+doc1	0	3
+doc2	1	4
+doc3	2	3
+
+# 'bark' df incremented, 'meow' added as new term
+query II
+SELECT term, df FROM fts_main_docs.dict ORDER BY term
+----
+bark	2
+meow	1
+quack	1
+
+# stats updated
+query II
+SELECT num_docs, avgdl FROM fts_main_docs.stats
+----
+3	3.333333333333333
+
+# match_bm25 returns the new document for a term only it contains
+query I
+SELECT id FROM (SELECT *, fts_main_docs.match_bm25(id, 'meowing') AS score FROM docs) sq
+WHERE score IS NOT NULL
+----
+doc3
+
+# multi-row insert updates every FTS table
+statement ok
+INSERT INTO docs VALUES ('doc6', 'barking chirping chirping'), ('doc7', 'meowing quacking quacking')
+
+query III rowsort
+SELECT name, docid, len FROM fts_main_docs.docs
+----
+doc1	0	3
+doc2	1	4
+doc3	2	3
+doc6	3	3
+doc7	4	3
+
+query II
+SELECT fieldid, field FROM fts_main_docs.fields
+----
+0	body
+
+query I
+SELECT count(*) FROM fts_main_docs.stopwords
+----
+0
+
+query II
+SELECT term, df FROM fts_main_docs.dict ORDER BY term
+----
+bark	3
+chirp	1
+meow	2
+quack	2
+
+query III rowsort
+SELECT d.name, dict.term, count(*) AS tf
+FROM fts_main_docs.terms AS t
+JOIN fts_main_docs.docs AS d ON t.docid = d.docid
+JOIN fts_main_docs.dict AS dict ON t.termid = dict.termid
+GROUP BY d.name, dict.term
+----
+doc1	quack	3
+doc2	bark	4
+doc3	bark	1
+doc3	meow	2
+doc6	bark	1
+doc6	chirp	2
+doc7	meow	1
+doc7	quack	2
+
+query II
+SELECT num_docs, avgdl FROM fts_main_docs.stats
+----
+5	3.2
+
+query I rowsort
+SELECT id FROM (SELECT *, fts_main_docs.match_bm25(id, 'chirping') AS score FROM docs) sq
+WHERE score IS NOT NULL
+----
+doc6
+
+# drop removes the trigger so a subsequent insert does not update the index
+statement ok
+PRAGMA drop_fts_index('docs')
+
+statement ok
+INSERT INTO docs VALUES ('doc4', 'squawking squawking')
+
+query I
+SELECT count(*) FROM duckdb_schemas() WHERE schema_name = 'fts_main_docs'
+----
+0
+
+statement ok
+PRAGMA create_fts_index('docs', 'id', 'body', stemmer='porter', stopwords='none')
+
+# doc4 is now in the index (full rebuild)
+query I
+SELECT count(*) FROM fts_main_docs.docs
+----
+6
+
+# overwrite drops the old trigger and recreates it; insert after overwrite still updates index
+statement ok
+PRAGMA create_fts_index('docs', 'id', 'body', stemmer='porter', stopwords='none', overwrite=true)
+
+statement ok
+INSERT INTO docs VALUES ('doc5', 'hissing hissing hissing hissing hissing')
+
+query II rowsort
+SELECT name, len FROM fts_main_docs.docs WHERE name = 'doc5'
+----
+doc5	5

--- a/test/sql/fts/test_incremental_insert_edge_cases.test
+++ b/test/sql/fts/test_incremental_insert_edge_cases.test
@@ -1,0 +1,50 @@
+# name: test/sql/fts/test_incremental_insert_edge_cases.test
+# description: Temporary FTS incremental update edge cases
+# group: [fts]
+
+require fts
+
+require skip_reload
+
+require no_alternative_verify
+
+# Overwriting an incremental index with the default non-incremental index should
+# remove the old INSERT triggers.
+statement ok
+CREATE TABLE docs(id VARCHAR, body VARCHAR)
+
+statement ok
+INSERT INTO docs VALUES ('doc1', 'quacking')
+
+statement ok
+PRAGMA create_fts_index('docs', 'id', 'body', stemmer='porter', stopwords='none', incremental=true)
+
+query I
+SELECT count(*) FROM duckdb_triggers() WHERE trigger_name LIKE '__fts_%'
+----
+5
+
+statement ok
+PRAGMA create_fts_index('docs', 'id', 'body', stemmer='porter', stopwords='none', overwrite=true)
+
+query I
+SELECT count(*) FROM duckdb_triggers() WHERE trigger_name LIKE '__fts_%'
+----
+0
+
+statement ok
+INSERT INTO docs VALUES ('doc2', 'barking')
+
+query I
+SELECT count(*) FROM fts_main_docs.docs
+----
+1
+
+query I
+SELECT count(*) FROM (
+    SELECT *, fts_main_docs.match_bm25(id, 'barking') AS score
+    FROM docs
+) sq
+WHERE score IS NOT NULL
+----
+0

--- a/test/sql/fts/test_incremental_insert_old_storage.test
+++ b/test/sql/fts/test_incremental_insert_old_storage.test
@@ -1,0 +1,46 @@
+# name: test/sql/fts/test_incremental_insert_old_storage.test
+# description: Test incremental FTS index creation on old persistent storage
+# group: [fts]
+
+require noforcestorage
+
+require skip_reload
+
+require fts
+
+require no_alternative_verify
+
+statement ok
+ATTACH '__TEST_DIR__/fts_old_storage.db' AS old_fts (STORAGE_VERSION 'v1.5.0')
+
+statement ok
+CREATE TABLE old_fts.main.docs (id VARCHAR, body VARCHAR)
+
+statement ok
+INSERT INTO old_fts.main.docs VALUES ('doc1', 'quacking')
+
+statement error
+PRAGMA create_fts_index('old_fts.main.docs', 'id', 'body', stemmer='porter', stopwords='none', incremental=true)
+----
+incremental FTS indexes require trigger support
+
+query I
+SELECT count(*) FROM duckdb_schemas() WHERE database_name = 'old_fts' AND schema_name = 'fts_main_docs'
+----
+0
+
+statement ok
+PRAGMA create_fts_index('old_fts.main.docs', 'id', 'body', stemmer='porter', stopwords='none')
+
+statement ok
+INSERT INTO old_fts.main.docs VALUES ('doc2', 'barking')
+
+query I
+SELECT count(*) FROM old_fts.fts_main_docs.docs
+----
+1
+
+query I
+SELECT count(*) FROM duckdb_triggers() WHERE database_name = 'old_fts' AND trigger_name LIKE '__fts_%'
+----
+0


### PR DESCRIPTION
cc @kryonix 

This PR adds the ability for the index created by the FTS extension to be updated whenever new data is inserted into the `input_table`. It uses the new `CREATE TRIGGER` to maintain a full SQL-based implementation of the index. 

Since triggers only work with storage version `2.0.0`, I added it as an option to the `create_fts_index()` pragma called `incremental`, which is by default false. 

Note: This PR assumes only `INSERT`, but not yet `DELETE`s from the table. That is for the next PR. 


The PR also adds code quality checks to the workflow, similar to other extensions :)