### PR TITLE
Update FTS index on `DELETE`

### DIFF
--- a/src/fts_indexing.cpp
+++ b/src/fts_indexing.cpp
@@ -8,6 +8,8 @@
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/main/connection.hpp"
+#include "duckdb/parser/constraints/not_null_constraint.hpp"
+#include "duckdb/parser/constraints/unique_constraint.hpp"
 #include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/storage/storage_info.hpp"
 #include "duckdb/storage/storage_manager.hpp"
@@ -49,10 +51,23 @@ static string GetQualifiedTableName(const QualifiedName &qname) {
   return StringUtil::Join(parts, ".");
 }
 
-static vector<string> GetFTSTriggerNames(const QualifiedName &qname) {
+static vector<string> GetFTSInsertTriggerNames(const QualifiedName &qname) {
   auto prefix = StringUtil::Format("__fts_%s_ai_", GetFTSSchemaName(qname));
   return {prefix + "00_docs", prefix + "10_dict_insert", prefix + "20_terms",
           prefix + "30_dict_df", prefix + "40_stats"};
+}
+
+static vector<string> GetFTSDeleteTriggerNames(const QualifiedName &qname) {
+  auto prefix = StringUtil::Format("__fts_%s_ad_", GetFTSSchemaName(qname));
+  return {prefix + "00_terms", prefix + "10_docs", prefix + "20_dict_df",
+          prefix + "30_dict_prune", prefix + "40_stats"};
+}
+
+static vector<string> GetFTSTriggerNames(const QualifiedName &qname) {
+  auto result = GetFTSInsertTriggerNames(qname);
+  auto delete_triggers = GetFTSDeleteTriggerNames(qname);
+  result.insert(result.end(), delete_triggers.begin(), delete_triggers.end());
+  return result;
 }
 
 static bool TableExists(ClientContext &context, const QualifiedName &qname) {
@@ -71,6 +86,31 @@ static bool SupportsFTSTriggers(ClientContext &context,
   auto &storage_manager = attached.GetStorageManager();
   return storage_manager.InMemory() ||
          storage_manager.GetStorageVersion() >= StorageVersion::V2_0_0;
+}
+
+static bool ColumnHasNotNullConstraint(const TableCatalogEntry &table,
+                                       const string &column_name) {
+  auto column_identifier = Identifier(column_name);
+  auto column_index = table.GetColumnIndex(column_identifier);
+  for (auto &constraint : table.GetConstraints()) {
+    if (constraint->type == ConstraintType::NOT_NULL) {
+      auto &not_null = constraint->Cast<NotNullConstraint>();
+      if (not_null.index == column_index) {
+        return true;
+      }
+    } else if (constraint->type == ConstraintType::UNIQUE) {
+      auto &unique = constraint->Cast<UniqueConstraint>();
+      if (!unique.IsPrimaryKey()) {
+        continue;
+      }
+      for (auto &pk_index : unique.GetLogicalIndexes(table.GetColumns())) {
+        if (pk_index == column_index) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -303,6 +343,14 @@ static string DropFTSTriggersScript(const QualifiedName &qname) {
   return StringUtil::Join(statements, "\n");
 }
 
+static string IncrementalIndexSetupScript(const QualifiedName &qname) {
+  auto index_name =
+      StringUtil::Format("__fts_%s_docs_name_idx", GetFTSSchemaName(qname));
+  return StringUtil::Format(
+      "CREATE UNIQUE INDEX %s ON %%fts_schema%%.docs(name);",
+      SQLIdentifier::ToString(index_name));
+}
+
 static string InsertTriggerScript(const QualifiedName &qname,
                                   const string &input_id,
                                   const vector<string> &input_values) {
@@ -474,6 +522,69 @@ static string InsertTriggerScript(const QualifiedName &qname,
   return result;
 }
 
+static string DeleteTriggerScript(const QualifiedName &qname,
+                                  const string &input_id) {
+  // clang-format off
+	string result = R"(
+        CREATE TRIGGER %trigger_00_terms% AFTER DELETE ON %input_table%
+        REFERENCING OLD TABLE AS fts_old_rows
+        FOR EACH STATEMENT
+            DELETE FROM %fts_schema%.terms
+            WHERE docid IN (
+                SELECT d.docid
+                FROM %fts_schema%.docs AS d
+                JOIN fts_old_rows AS old_rows ON d.name = old_rows.%input_id%
+            );
+
+        CREATE TRIGGER %trigger_10_docs% AFTER DELETE ON %input_table%
+        REFERENCING OLD TABLE AS fts_old_rows
+        FOR EACH STATEMENT
+            DELETE FROM %fts_schema%.docs
+            WHERE name IN (SELECT %input_id% FROM fts_old_rows);
+
+        CREATE TRIGGER %trigger_20_dict_df% AFTER DELETE ON %input_table%
+        REFERENCING OLD TABLE AS fts_old_rows
+        FOR EACH STATEMENT
+            UPDATE %fts_schema%.dict AS d
+            SET df = (
+                SELECT count(DISTINCT docid)
+                FROM %fts_schema%.terms AS t
+                WHERE d.termid = t.termid
+            );
+
+        CREATE TRIGGER %trigger_30_dict_prune% AFTER DELETE ON %input_table%
+        REFERENCING OLD TABLE AS fts_old_rows
+        FOR EACH STATEMENT
+            DELETE FROM %fts_schema%.dict
+            WHERE df = 0;
+
+        CREATE TRIGGER %trigger_40_stats% AFTER DELETE ON %input_table%
+        REFERENCING OLD TABLE AS fts_old_rows
+        FOR EACH STATEMENT
+            UPDATE %fts_schema%.stats
+            SET num_docs = (SELECT COUNT(docid) FROM %fts_schema%.docs),
+                avgdl = (SELECT SUM(len) / COUNT(len) FROM %fts_schema%.docs);
+    )";
+  // clang-format on
+
+  auto trigger_names = GetFTSDeleteTriggerNames(qname);
+  result = StringUtil::Replace(result, "%trigger_00_terms%",
+                               SQLIdentifier::ToString(trigger_names[0]));
+  result = StringUtil::Replace(result, "%trigger_10_docs%",
+                               SQLIdentifier::ToString(trigger_names[1]));
+  result = StringUtil::Replace(result, "%trigger_20_dict_df%",
+                               SQLIdentifier::ToString(trigger_names[2]));
+  result = StringUtil::Replace(result, "%trigger_30_dict_prune%",
+                               SQLIdentifier::ToString(trigger_names[3]));
+  result = StringUtil::Replace(result, "%trigger_40_stats%",
+                               SQLIdentifier::ToString(trigger_names[4]));
+  result = StringUtil::Replace(result, "%input_table%",
+                               GetQualifiedTableName(qname));
+  result = StringUtil::Replace(result, "%input_id%",
+                               SQLIdentifier::ToString(input_id));
+  return result;
+}
+
 // ---------------------------------------------------------------------------
 // Coordinator: assembles all parts and substitutes cross-cutting placeholders
 // ---------------------------------------------------------------------------
@@ -494,7 +605,9 @@ static string IndexingScript(ClientContext &context, QualifiedName &qname,
   result += IndexTablesScript(input_id, input_values);
   result += MatchMacroScript();
   if (incremental) {
+    result += IncrementalIndexSetupScript(qname);
     result += InsertTriggerScript(qname, input_id, input_values);
+    result += DeleteTriggerScript(qname, input_id);
   }
 
   string fts_schema = GetFTSSchema(qname);
@@ -587,6 +700,11 @@ string FTSIndexing::CreateFTSIndexQuery(ClientContext &context,
   const string doc_id = StringValue::Get(parameters.values[1]);
   auto &table = Catalog::GetEntry<TableCatalogEntry>(context, qname.catalog,
                                                      qname.schema, qname.name);
+  if (!table.ColumnExists(Identifier(doc_id))) {
+    throw CatalogException("Table '%s.%s' does not have a column named '%s'!",
+                           qname.schema.GetIdentifierName(),
+                           qname.name.GetIdentifierName(), doc_id);
+  }
   vector<string> doc_values;
   for (idx_t i = 2; i < parameters.values.size(); i++) {
     const string col_name = StringValue::Get(parameters.values[i]);
@@ -616,6 +734,10 @@ string FTSIndexing::CreateFTSIndexQuery(ClientContext &context,
         "databases must use storage version v2.0.0 or higher; reattach/create "
         "the database with STORAGE_VERSION 'v2.0.0', or omit incremental=true "
         "to create a rebuild-only FTS index.");
+  }
+  if (incremental && !ColumnHasNotNullConstraint(table, doc_id)) {
+    throw InvalidInputException("incremental FTS indexes require the document "
+                                "id column to be NOT NULL");
   }
 
   return IndexingScript(context, qname, doc_id, doc_values, stemmer, stopwords,

--- a/test/sql/fts/test_identifier_quoting.test
+++ b/test/sql/fts/test_identifier_quoting.test
@@ -10,7 +10,7 @@ require no_alternative_verify
 
 # Quoted table names should be valid FTS input table names.
 statement ok
-CREATE TABLE "my docs"(id VARCHAR, body VARCHAR)
+CREATE TABLE "my docs"(id VARCHAR NOT NULL, body VARCHAR)
 
 statement ok
 INSERT INTO "my docs" VALUES ('doc1', 'quacking')
@@ -26,7 +26,7 @@ doc1	1
 # Indexed column names containing quotes should be escaped when building the
 # initial index SQL.
 statement ok
-CREATE TABLE quote_col(id VARCHAR, "bo""dy" VARCHAR)
+CREATE TABLE quote_col(id VARCHAR NOT NULL, "bo""dy" VARCHAR)
 
 statement ok
 INSERT INTO quote_col VALUES ('doc1', 'quacking')
@@ -40,7 +40,7 @@ SELECT fieldid, field FROM fts_main_quote_col.fields
 0	bo"dy
 
 statement ok
-CREATE TABLE single_quote_col(id VARCHAR, "bo'dy" VARCHAR)
+CREATE TABLE single_quote_col(id VARCHAR NOT NULL, "bo'dy" VARCHAR)
 
 statement ok
 INSERT INTO single_quote_col VALUES ('doc1', 'quacking')

--- a/test/sql/fts/test_incremental_insert.test
+++ b/test/sql/fts/test_incremental_insert.test
@@ -29,7 +29,7 @@ statement ok
 PRAGMA drop_fts_index('static_docs')
 
 statement ok
-CREATE TABLE docs (id VARCHAR, body VARCHAR)
+CREATE TABLE docs (id VARCHAR NOT NULL, body VARCHAR)
 
 statement ok
 INSERT INTO docs VALUES ('doc1', 'quacking quacking quacking'), ('doc2', 'barking barking barking barking')
@@ -141,6 +141,84 @@ WHERE score IS NOT NULL
 ----
 doc6
 
+# multi-row delete updates docs, terms, dict, and stats
+statement ok
+DELETE FROM docs WHERE id IN ('doc3', 'doc7')
+
+query III rowsort
+SELECT name, docid, len FROM fts_main_docs.docs
+----
+doc1	0	3
+doc2	1	4
+doc6	3	3
+
+query II
+SELECT term, df FROM fts_main_docs.dict ORDER BY term
+----
+bark	2
+chirp	1
+quack	1
+
+query III rowsort
+SELECT d.name, dict.term, count(*) AS tf
+FROM fts_main_docs.terms AS t
+JOIN fts_main_docs.docs AS d ON t.docid = d.docid
+JOIN fts_main_docs.dict AS dict ON t.termid = dict.termid
+GROUP BY d.name, dict.term
+----
+doc1	quack	3
+doc2	bark	4
+doc6	bark	1
+doc6	chirp	2
+
+query I
+SELECT count(*) FROM fts_main_docs.terms
+----
+10
+
+query I
+SELECT count(*)
+FROM fts_main_docs.terms AS t
+LEFT JOIN fts_main_docs.docs AS d ON t.docid = d.docid
+WHERE d.docid IS NULL
+----
+0
+
+query I
+SELECT count(*)
+FROM fts_main_docs.terms AS t
+LEFT JOIN fts_main_docs.dict AS dict ON t.termid = dict.termid
+WHERE dict.termid IS NULL
+----
+0
+
+query II
+SELECT num_docs, avgdl FROM fts_main_docs.stats
+----
+3	3.333333333333333
+
+query I rowsort
+SELECT id FROM (SELECT *, fts_main_docs.match_bm25(id, 'quacking') AS score FROM docs) sq
+WHERE score IS NOT NULL
+----
+doc1
+
+query I rowsort
+SELECT id FROM (SELECT *, fts_main_docs.match_bm25(id, 'barking') AS score FROM docs) sq
+WHERE score IS NOT NULL
+----
+doc2
+doc6
+
+query I
+SELECT count(*) FROM (
+    SELECT *, fts_main_docs.match_bm25(id, 'meowing') AS score
+    FROM docs
+) sq
+WHERE score IS NOT NULL
+----
+0
+
 # drop removes the trigger so a subsequent insert does not update the index
 statement ok
 PRAGMA drop_fts_index('docs')
@@ -160,7 +238,7 @@ PRAGMA create_fts_index('docs', 'id', 'body', stemmer='porter', stopwords='none'
 query I
 SELECT count(*) FROM fts_main_docs.docs
 ----
-6
+4
 
 # overwrite drops the old trigger and recreates it; insert after overwrite still updates index
 statement ok

--- a/test/sql/fts/test_incremental_insert_edge_cases.test
+++ b/test/sql/fts/test_incremental_insert_edge_cases.test
@@ -11,7 +11,7 @@ require no_alternative_verify
 # Overwriting an incremental index with the default non-incremental index should
 # remove the old INSERT triggers.
 statement ok
-CREATE TABLE docs(id VARCHAR, body VARCHAR)
+CREATE TABLE docs(id VARCHAR NOT NULL, body VARCHAR)
 
 statement ok
 INSERT INTO docs VALUES ('doc1', 'quacking')
@@ -22,7 +22,7 @@ PRAGMA create_fts_index('docs', 'id', 'body', stemmer='porter', stopwords='none'
 query I
 SELECT count(*) FROM duckdb_triggers() WHERE trigger_name LIKE '__fts_%'
 ----
-5
+10
 
 statement ok
 PRAGMA create_fts_index('docs', 'id', 'body', stemmer='porter', stopwords='none', overwrite=true)
@@ -48,3 +48,42 @@ SELECT count(*) FROM (
 WHERE score IS NOT NULL
 ----
 0
+
+statement ok
+CREATE TABLE primary_key_docs(id VARCHAR PRIMARY KEY, body VARCHAR)
+
+statement ok
+INSERT INTO primary_key_docs VALUES ('doc1', 'quacking')
+
+statement ok
+PRAGMA create_fts_index('primary_key_docs', 'id', 'body', stemmer='porter', stopwords='none', incremental=true)
+
+query II
+SELECT name, len FROM fts_main_primary_key_docs.docs
+----
+doc1	1
+
+# Incremental indexes require unique document ids so DELETE triggers do not
+# remove multiple indexed documents for a single deleted source row.
+statement ok
+CREATE TABLE duplicate_docs(id VARCHAR NOT NULL, body VARCHAR)
+
+statement ok
+INSERT INTO duplicate_docs VALUES ('dup', 'quacking'), ('dup', 'barking')
+
+statement error
+PRAGMA create_fts_index('duplicate_docs', 'id', 'body', stemmer='porter', stopwords='none', incremental=true)
+----
+
+# Incremental indexes require the document id column to be declared NOT NULL so
+# DELETE triggers can always match indexed documents by id.
+statement ok
+CREATE TABLE nullable_docs(id VARCHAR, body VARCHAR)
+
+statement ok
+INSERT INTO nullable_docs VALUES (NULL, 'quacking')
+
+statement error
+PRAGMA create_fts_index('nullable_docs', 'id', 'body', stemmer='porter', stopwords='none', incremental=true)
+----
+incremental FTS indexes require the document id column to be NOT NULL


### PR DESCRIPTION
Part of: https://github.com/duckdblabs/duckdb-internal/issues/9698

This PR now ensures that after a `DELETE` on the documents table the FTS index is updated properly. It uses the `CREATE TRIGGER AFTER DELETE`. It removes documents from the `terms` table, deletes rows from `docs`, it prunes dictionary terms whose df becomes zero, updates the counts and refreshes the stats. 

It does come with a constraint, namely that the document `id` column in the `documents` table must be `NOT NULL`, to avoid equality checks getting incorrect results (This is only a constraint when you set `incremental=true`). 