### PR TITLE
Maintain dict df incrementally rather than full rebuild

### DIFF
--- a/src/fts_indexing.cpp
+++ b/src/fts_indexing.cpp
@@ -801,6 +801,10 @@ string FTSIndexing::CreateFTSIndexQuery(ClientContext &context,
     throw InvalidInputException("incremental FTS indexes require the document "
                                 "id column to be NOT NULL");
   }
+  if (incremental && cluster_terms) {
+    throw InvalidInputException("cluster_terms cannot be combined with "
+                                "incremental FTS indexes");
+  }
 
   return IndexingScript(context, qname, doc_id, doc_values, stemmer, stopwords,
                         ignore, strip_accents, lower, incremental,

--- a/src/fts_indexing.cpp
+++ b/src/fts_indexing.cpp
@@ -59,7 +59,7 @@ static vector<string> GetFTSInsertTriggerNames(const QualifiedName &qname) {
 
 static vector<string> GetFTSDeleteTriggerNames(const QualifiedName &qname) {
   auto prefix = StringUtil::Format("__fts_%s_ad_", GetFTSSchemaName(qname));
-  return {prefix + "00_terms", prefix + "10_docs", prefix + "20_dict_df",
+  return {prefix + "00_dict_df", prefix + "10_terms", prefix + "20_docs",
           prefix + "30_dict_prune", prefix + "40_stats"};
 }
 
@@ -458,11 +458,16 @@ static string InsertTriggerScript(const QualifiedName &qname,
         REFERENCING NEW TABLE AS fts_new_rows
         FOR EACH STATEMENT
             UPDATE %fts_schema%.dict AS d
-            SET df = (
-                SELECT count(DISTINCT docid)
+            SET df = d.df + inserted_df_delta.df_delta
+            FROM (
+                SELECT t.termid,
+                       COUNT(DISTINCT t.docid) AS df_delta
                 FROM %fts_schema%.terms AS t
-                WHERE d.termid = t.termid
-            );
+                JOIN %fts_schema%.docs AS docs ON t.docid = docs.docid
+                JOIN fts_new_rows AS new_rows ON docs.name = new_rows.%input_id%
+                GROUP BY t.termid
+            ) AS inserted_df_delta
+            WHERE d.termid = inserted_df_delta.termid;
 
         CREATE TRIGGER %trigger_40_stats% AFTER INSERT ON %input_table%
         REFERENCING NEW TABLE AS fts_new_rows
@@ -526,7 +531,22 @@ static string DeleteTriggerScript(const QualifiedName &qname,
                                   const string &input_id) {
   // clang-format off
 	string result = R"(
-        CREATE TRIGGER %trigger_00_terms% AFTER DELETE ON %input_table%
+        CREATE TRIGGER %trigger_00_dict_df% AFTER DELETE ON %input_table%
+        REFERENCING OLD TABLE AS fts_old_rows
+        FOR EACH STATEMENT
+            UPDATE %fts_schema%.dict AS d
+            SET df = d.df - deleted_df_delta.df_delta
+            FROM (
+                SELECT t.termid,
+                       COUNT(DISTINCT t.docid) AS df_delta
+                FROM %fts_schema%.terms AS t
+                JOIN %fts_schema%.docs AS docs ON t.docid = docs.docid
+                JOIN fts_old_rows AS old_rows ON docs.name = old_rows.%input_id%
+                GROUP BY t.termid
+            ) AS deleted_df_delta
+            WHERE d.termid = deleted_df_delta.termid;
+
+        CREATE TRIGGER %trigger_10_terms% AFTER DELETE ON %input_table%
         REFERENCING OLD TABLE AS fts_old_rows
         FOR EACH STATEMENT
             DELETE FROM %fts_schema%.terms
@@ -536,21 +556,11 @@ static string DeleteTriggerScript(const QualifiedName &qname,
                 JOIN fts_old_rows AS old_rows ON d.name = old_rows.%input_id%
             );
 
-        CREATE TRIGGER %trigger_10_docs% AFTER DELETE ON %input_table%
+        CREATE TRIGGER %trigger_20_docs% AFTER DELETE ON %input_table%
         REFERENCING OLD TABLE AS fts_old_rows
         FOR EACH STATEMENT
             DELETE FROM %fts_schema%.docs
             WHERE name IN (SELECT %input_id% FROM fts_old_rows);
-
-        CREATE TRIGGER %trigger_20_dict_df% AFTER DELETE ON %input_table%
-        REFERENCING OLD TABLE AS fts_old_rows
-        FOR EACH STATEMENT
-            UPDATE %fts_schema%.dict AS d
-            SET df = (
-                SELECT count(DISTINCT docid)
-                FROM %fts_schema%.terms AS t
-                WHERE d.termid = t.termid
-            );
 
         CREATE TRIGGER %trigger_30_dict_prune% AFTER DELETE ON %input_table%
         REFERENCING OLD TABLE AS fts_old_rows
@@ -568,11 +578,11 @@ static string DeleteTriggerScript(const QualifiedName &qname,
   // clang-format on
 
   auto trigger_names = GetFTSDeleteTriggerNames(qname);
-  result = StringUtil::Replace(result, "%trigger_00_terms%",
+  result = StringUtil::Replace(result, "%trigger_00_dict_df%",
                                SQLIdentifier::ToString(trigger_names[0]));
-  result = StringUtil::Replace(result, "%trigger_10_docs%",
+  result = StringUtil::Replace(result, "%trigger_10_terms%",
                                SQLIdentifier::ToString(trigger_names[1]));
-  result = StringUtil::Replace(result, "%trigger_20_dict_df%",
+  result = StringUtil::Replace(result, "%trigger_20_docs%",
                                SQLIdentifier::ToString(trigger_names[2]));
   result = StringUtil::Replace(result, "%trigger_30_dict_prune%",
                                SQLIdentifier::ToString(trigger_names[3]));

--- a/test/sql/fts/test_incremental_dict_df_delta.test
+++ b/test/sql/fts/test_incremental_dict_df_delta.test
@@ -1,0 +1,211 @@
+# name: test/sql/fts/test_incremental_dict_df_delta.test
+# description: Test delta-maintained dictionary document frequencies for incremental FTS indexes
+# group: [fts]
+
+require fts
+
+require skip_reload
+
+require no_alternative_verify
+
+statement ok
+CREATE TABLE df_docs(id VARCHAR NOT NULL, body VARCHAR)
+
+statement ok
+INSERT INTO df_docs VALUES
+    ('doc1', 'hello hello hello'),
+    ('doc2', 'hello world')
+
+statement ok
+PRAGMA create_fts_index('df_docs', 'id', 'body', stemmer='porter', stopwords='none', incremental=true)
+
+query II
+SELECT term, df FROM fts_main_df_docs.dict ORDER BY term
+----
+hello	2
+world	1
+
+query I
+WITH recomputed AS (
+    SELECT termid, count(DISTINCT docid) AS df
+    FROM fts_main_df_docs.terms
+    GROUP BY termid
+),
+diffs AS (
+    SELECT COALESCE(d.termid, r.termid) AS termid
+    FROM fts_main_df_docs.dict AS d
+    FULL OUTER JOIN recomputed AS r USING (termid)
+    WHERE d.termid IS NULL
+       OR r.termid IS NULL
+       OR d.df IS DISTINCT FROM r.df
+)
+SELECT count(*) FROM diffs
+----
+0
+
+# Insert one document with repeated terms. `hello` should increment once, not by
+# the number of token occurrences in the document.
+statement ok
+INSERT INTO df_docs VALUES ('doc3', 'hello hello duck')
+
+query II
+SELECT term, df FROM fts_main_df_docs.dict ORDER BY term
+----
+duck	1
+hello	3
+world	1
+
+query I
+WITH recomputed AS (
+    SELECT termid, count(DISTINCT docid) AS df
+    FROM fts_main_df_docs.terms
+    GROUP BY termid
+),
+diffs AS (
+    SELECT COALESCE(d.termid, r.termid) AS termid
+    FROM fts_main_df_docs.dict AS d
+    FULL OUTER JOIN recomputed AS r USING (termid)
+    WHERE d.termid IS NULL
+       OR r.termid IS NULL
+       OR d.df IS DISTINCT FROM r.df
+)
+SELECT count(*) FROM diffs
+----
+0
+
+# Multi-row insert with shared terms should count documents, not rows or tokens.
+statement ok
+INSERT INTO df_docs VALUES
+    ('doc4', 'world world'),
+    ('doc5', 'hello world')
+
+query II
+SELECT term, df FROM fts_main_df_docs.dict ORDER BY term
+----
+duck	1
+hello	4
+world	3
+
+query I
+WITH recomputed AS (
+    SELECT termid, count(DISTINCT docid) AS df
+    FROM fts_main_df_docs.terms
+    GROUP BY termid
+),
+diffs AS (
+    SELECT COALESCE(d.termid, r.termid) AS termid
+    FROM fts_main_df_docs.dict AS d
+    FULL OUTER JOIN recomputed AS r USING (termid)
+    WHERE d.termid IS NULL
+       OR r.termid IS NULL
+       OR d.df IS DISTINCT FROM r.df
+)
+SELECT count(*) FROM diffs
+----
+0
+
+# Delete one document with repeated terms.
+statement ok
+DELETE FROM df_docs WHERE id = 'doc1'
+
+query II
+SELECT term, df FROM fts_main_df_docs.dict ORDER BY term
+----
+duck	1
+hello	3
+world	3
+
+query I
+WITH recomputed AS (
+    SELECT termid, count(DISTINCT docid) AS df
+    FROM fts_main_df_docs.terms
+    GROUP BY termid
+),
+diffs AS (
+    SELECT COALESCE(d.termid, r.termid) AS termid
+    FROM fts_main_df_docs.dict AS d
+    FULL OUTER JOIN recomputed AS r USING (termid)
+    WHERE d.termid IS NULL
+       OR r.termid IS NULL
+       OR d.df IS DISTINCT FROM r.df
+)
+SELECT count(*) FROM diffs
+----
+0
+
+# Delete the last document containing a term; the dictionary row should be
+# pruned after its df reaches zero.
+statement ok
+DELETE FROM df_docs WHERE id = 'doc3'
+
+query II
+SELECT term, df FROM fts_main_df_docs.dict ORDER BY term
+----
+hello	2
+world	3
+
+query I
+WITH recomputed AS (
+    SELECT termid, count(DISTINCT docid) AS df
+    FROM fts_main_df_docs.terms
+    GROUP BY termid
+),
+diffs AS (
+    SELECT COALESCE(d.termid, r.termid) AS termid
+    FROM fts_main_df_docs.dict AS d
+    FULL OUTER JOIN recomputed AS r USING (termid)
+    WHERE d.termid IS NULL
+       OR r.termid IS NULL
+       OR d.df IS DISTINCT FROM r.df
+)
+SELECT count(*) FROM diffs
+----
+0
+
+# Logical update pattern: delete a document and insert its replacement with the
+# same document id.
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+DELETE FROM df_docs WHERE id = 'doc2'
+
+statement ok
+INSERT INTO df_docs VALUES ('doc2', 'hello hello zebra')
+
+statement ok
+COMMIT
+
+query II
+SELECT term, df FROM fts_main_df_docs.dict ORDER BY term
+----
+hello	2
+world	2
+zebra	1
+
+query I
+WITH recomputed AS (
+    SELECT termid, count(DISTINCT docid) AS df
+    FROM fts_main_df_docs.terms
+    GROUP BY termid
+),
+diffs AS (
+    SELECT COALESCE(d.termid, r.termid) AS termid
+    FROM fts_main_df_docs.dict AS d
+    FULL OUTER JOIN recomputed AS r USING (termid)
+    WHERE d.termid IS NULL
+       OR r.termid IS NULL
+       OR d.df IS DISTINCT FROM r.df
+)
+SELECT count(*) FROM diffs
+----
+0
+
+query I rowsort
+SELECT id FROM (
+    SELECT *, fts_main_df_docs.match_bm25(id, 'zebra') AS score
+    FROM df_docs
+) sq
+WHERE score IS NOT NULL
+----
+doc2

--- a/test/sql/fts/test_incremental_insert_edge_cases.test
+++ b/test/sql/fts/test_incremental_insert_edge_cases.test
@@ -63,6 +63,19 @@ SELECT name, len FROM fts_main_primary_key_docs.docs
 ----
 doc1	1
 
+# Clustered terms are a static physical layout; incremental inserts would append
+# new terms after the clustered build and invalidate that ordering guarantee.
+statement ok
+CREATE TABLE clustered_incremental_docs(id VARCHAR NOT NULL, body VARCHAR)
+
+statement ok
+INSERT INTO clustered_incremental_docs VALUES ('doc1', 'alpha beta')
+
+statement error
+PRAGMA create_fts_index('clustered_incremental_docs', 'id', 'body', stemmer='none', stopwords='none', incremental=true, cluster_terms=true)
+----
+cluster_terms cannot be combined with incremental FTS indexes
+
 # Incremental indexes require unique document ids so DELETE triggers do not
 # remove multiple indexed documents for a single deleted source row.
 statement ok


### PR DESCRIPTION
This PR changes incremental FTS deletes so we maintain dict.df incrementally instead of rebuilding it from the full terms table after every delete.

Previously, we were paying a big cost also if the number of rows changed was small for deletes. With this change, we change document frequency entries directly, making the incremental index scale better with the size of the update. 

For now, if you enable both `incremental` and `clustered` I throw an error. I'll make sure this works in a follow-up PR. 

I did some benchmarks against `main` (M5 Pro) running just deletes (batch size of 1 means delete 1 document), each number below is a median of 5 runs: 

| Documents | Batch | Main incremental | This PR incremental | Improvement |
|---:|---:|---:|---:|---:|
| 626 | 1 | 3.37 ms | 2.86 ms | 15.2% faster |
| 626 | 10 | 3.86 ms | 3.46 ms | 10.4% faster |
| 626 | 100 | 3.80 ms | 3.74 ms | 1.6% faster |
| 626 | 500 | 4.67 ms | 4.20 ms | 10.1% faster |
| 2,689 | 1 | 5.15 ms | 2.65 ms | 48.5% faster |
| 2,689 | 10 | 5.71 ms | 3.38 ms | 40.8% faster |
| 2,689 | 100 | 5.58 ms | 3.78 ms | 32.1% faster |
| 2,689 | 500 | 5.48 ms | 4.47 ms | 18.4% faster |
| 3,315 | 1 | 5.10 ms | 3.18 ms | 37.6% faster |
| 3,315 | 10 | 5.24 ms | 3.79 ms | 27.7% faster |
| 3,315 | 100 | 5.45 ms | 3.92 ms | 28.1% faster |
| 3,315 | 500 | 5.56 ms | 4.58 ms | 17.7% faster |
| 100,000 | 1 | 30.61 ms | 5.56 ms | 81.8% faster |
| 100,000 | 10 | 28.81 ms | 6.94 ms | 75.9% faster |
| 100,000 | 100 | 32.14 ms | 10.64 ms | 66.9% faster |
| 100,000 | 500 | 39.56 ms | 20.08 ms | 49.3% faster |

Mixed workloads (insert + delete) improved too, especially at smaller batch sizes. On the 100k dataset, `mixed_delete_insert` was between 19.8% and 75.5% faster depending on batch size.
