### PR TITLE
Allow statically link using command line option

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -1,9 +1,13 @@
 # This file is included by DuckDB's build system. It specifies which extension to load
+set(FTS_DONT_LINK DONT_LINK)
+if (LINK_FTS_STATICALLY)
+    set(FTS_DONT_LINK "")
+endif()
 
 # Extension from this repo
 duckdb_extension_load(fts
-    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/extension/fts/include
-    ${LOAD_FTS_TESTS}
-    DONT_LINK
+        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
+        INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/src/include
+        ${LOAD_FTS_TESTS}
+        ${FTS_DONT_LINK}
 )

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -6,8 +6,8 @@ endif()
 
 # Extension from this repo
 duckdb_extension_load(fts
-        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-        INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/src/include
-        ${LOAD_FTS_TESTS}
-        ${FTS_DONT_LINK}
+    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
+    INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/src/include
+    ${LOAD_FTS_TESTS}
+    ${FTS_DONT_LINK}
 )


### PR DESCRIPTION
Makes it easier to statically link the extension without having to change the config file. Also fixes the path, which after https://github.com/duckdb/duckdb-fts/pull/26 no longer pointed to the correct location.

To statically link: 
`make release EXT_FLAGS="-DLINK_FTS_STATICALLY=1"`
