### PR TITLE
Improve Opensearch standard tokenizer accent handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ create_fts_index(input_table, input_id, *input_values, stemmer = 'porter',
 | `tokenizer` | `VARCHAR` | Tokenizer to use. `'regex'` keeps the legacy regex-split behavior. `'opensearch_standard'` uses an OpenSearch/Lucene standard-tokenizer compatibility mode that splits Han, Hiragana, and Katakana into single-character tokens while preserving word runs for scripts such as Hebrew, Cyrillic, Arabic, Latin, and Hangul. Defaults to `'regex'` |
 | `stopwords` | `VARCHAR` | Qualified name of table containing a single `VARCHAR` column containing the desired stopwords, or `'none'` if no stopwords are to be used. Defaults to `'english'` for a pre-defined list of 571 English stopwords |
 | `ignore` | `VARCHAR` | Regular expression of patterns to be ignored by the `'regex'` tokenizer. Defaults to a punctuation and digit pattern |
-| `strip_accents` | `BOOLEAN` | Whether to remove accents (e.g., convert `á` to `a`). Defaults to `1` |
+| `strip_accents` | `BOOLEAN` | Whether to remove accents (e.g., convert `á` to `a`). Defaults to `1` for `'regex'` and `0` for `'opensearch_standard'`. `strip_accents=true` is not supported with `'opensearch_standard'` because OpenSearch's standard analyzer lowercases tokens but does not strip accents |
 | `lower` | `BOOLEAN` | Whether to convert all text to lowercase. Defaults to `1` |
 | `overwrite` | `BOOLEAN` | Whether to overwrite an existing index on a table. Defaults to `0` |
 | `incremental` | `BOOLEAN` | Whether to maintain the FTS index with triggers after inserts and deletes on the input table. Defaults to `0` |

--- a/src/fts_extension.cpp
+++ b/src/fts_extension.cpp
@@ -27,6 +27,13 @@ static bool IsOpenSearchStandardEmoji(UChar32 codepoint) {
          u_hasBinaryProperty(codepoint, UCHAR_EXTENDED_PICTOGRAPHIC);
 }
 
+static bool IsOpenSearchStandardCombiningMark(UChar32 codepoint) {
+  auto char_type = u_charType(codepoint);
+  return char_type == U_NON_SPACING_MARK ||
+         char_type == U_COMBINING_SPACING_MARK ||
+         char_type == U_ENCLOSING_MARK;
+}
+
 static bool IsOpenSearchStandardIntraTokenPunctuation(UChar32 codepoint) {
   return codepoint == '\'' || codepoint == 0x2019 || codepoint == '.' ||
          codepoint == '_';
@@ -50,7 +57,8 @@ static bool IsOpenSearchStandardContinuationChar(UChar32 codepoint,
                                                  UScriptCode script) {
   return !IsOpenSearchStandardSingleTokenScript(script) &&
          !IsOpenSearchStandardEmoji(codepoint) &&
-         IsOpenSearchStandardTokenChar(codepoint, script);
+         (IsOpenSearchStandardTokenChar(codepoint, script) ||
+          IsOpenSearchStandardCombiningMark(codepoint));
 }
 
 template <class LIST_WRITER>
@@ -95,8 +103,16 @@ static void TokenizeOpenSearchStandard(string_t input, LIST_WRITER &list) {
       continue;
     }
 
-    if (IsOpenSearchStandardSingleTokenScript(script) ||
-        IsOpenSearchStandardEmoji(codepoint)) {
+    // Proper OpenSearch parity should delegate word boundary detection to
+    // Lucene's StandardTokenizer or ICU UBRK_WORD. DuckDB's bundled ICU build
+    // currently disables break iteration, so this scanner keeps the known
+    // OpenSearch-compatible cases local. Combining marks are continuations to
+    // preserve decomposed accents such as "cafe\u0301" rather than splitting or
+    // dropping the mark.
+    if (IsOpenSearchStandardCombiningMark(codepoint) && token_size > 0) {
+      token_size += UnsafeNumericCast<idx_t>(char_size);
+    } else if (IsOpenSearchStandardSingleTokenScript(script) ||
+               IsOpenSearchStandardEmoji(codepoint)) {
       flush_token();
       list.WriteElement().WriteStringRef(
           string_t(input_data + pos, UnsafeNumericCast<uint32_t>(char_size)));

--- a/src/fts_extension.cpp
+++ b/src/fts_extension.cpp
@@ -30,8 +30,7 @@ static bool IsOpenSearchStandardEmoji(UChar32 codepoint) {
 static bool IsOpenSearchStandardCombiningMark(UChar32 codepoint) {
   auto char_type = u_charType(codepoint);
   return char_type == U_NON_SPACING_MARK ||
-         char_type == U_COMBINING_SPACING_MARK ||
-         char_type == U_ENCLOSING_MARK;
+         char_type == U_COMBINING_SPACING_MARK || char_type == U_ENCLOSING_MARK;
 }
 
 static bool IsOpenSearchStandardIntraTokenPunctuation(UChar32 codepoint) {

--- a/src/fts_indexing.cpp
+++ b/src/fts_indexing.cpp
@@ -2156,24 +2156,38 @@ string FTSIndexing::CreateFTSIndexQuery(ClientContext &context,
                ? BooleanValue::Get(it->second)
                : def;
   };
+  auto has_named_parameter = [&](const string &name) {
+    return parameters.named_parameters.find(Identifier(name)) !=
+           parameters.named_parameters.end();
+  };
 
   const string stemmer = get_string("stemmer", "porter");
   const string tokenizer = get_string("tokenizer", "regex");
   const string stopwords = get_string("stopwords", "english");
   const string ignore =
       get_string("ignore", "[0-9!@#$%^&*()_+={}\\[\\]:;<>,.?~\\\\/\\|''\"`-]+");
-  const bool strip_accents = get_bool("strip_accents", true);
-  const bool lower = get_bool("lower", true);
-  const bool overwrite = get_bool("overwrite", false);
-  const bool incremental = get_bool("incremental", false);
-  const bool layered_search = get_bool("layered_search", false);
-  const bool cluster_terms = get_bool("cluster_terms", false) || layered_search;
 
   if (tokenizer != "regex" && tokenizer != "opensearch_standard") {
     throw InvalidInputException(
         "Unrecognized tokenizer '%s'. Supported tokenizers are: ['regex', "
         "'opensearch_standard']",
         tokenizer);
+  }
+
+  const bool strip_accents =
+      get_bool("strip_accents", tokenizer != "opensearch_standard");
+  const bool lower = get_bool("lower", true);
+  const bool overwrite = get_bool("overwrite", false);
+  const bool incremental = get_bool("incremental", false);
+  const bool layered_search = get_bool("layered_search", false);
+  const bool cluster_terms = get_bool("cluster_terms", false) || layered_search;
+
+  if (tokenizer == "opensearch_standard" && strip_accents &&
+      has_named_parameter("strip_accents")) {
+    throw InvalidInputException(
+        "strip_accents=true is not supported with tokenizer "
+        "'opensearch_standard'. OpenSearch's standard analyzer lowercases "
+        "tokens but does not strip accents; use strip_accents=false.");
   }
 
   if (stopwords != "english" && stopwords != "none") {

--- a/test/sql/fts/test_opensearch_standard_tokenizer.test
+++ b/test/sql/fts/test_opensearch_standard_tokenizer.test
@@ -94,6 +94,18 @@ WHERE term = 'cafe'
 ----
 0
 
+query T
+SELECT hex(token)
+FROM (
+    SELECT unnest(fts_tokenize_opensearch_standard(lower(
+        'cafe' || chr(769) || ' A' || chr(778) || 'ngström man' || chr(771) || 'ana'
+    ))) AS token
+)
+----
+63616665CC81
+61CC8A6E67737472C3B66D
+6D616ECC83616E61
+
 statement ok
 PRAGMA create_fts_index('unicode_docs', 'id', 'body', tokenizer='opensearch_standard', stemmer='none', stopwords='none', strip_accents=false, overwrite=true)
 

--- a/test/sql/fts/test_opensearch_standard_tokenizer.test
+++ b/test/sql/fts/test_opensearch_standard_tokenizer.test
@@ -40,7 +40,7 @@ statement ok
 CREATE TABLE unicode_docs(id VARCHAR, body VARCHAR)
 
 statement ok
-INSERT INTO unicode_docs VALUES ('doc1', 'תל-אביב ביב Привет-мир مرحبا-بالعالم 東京大学に行く 北京大学 한국어 테스트 café')
+INSERT INTO unicode_docs VALUES ('doc1', 'תל-אביב ביב Привет-мир مرحبا-بالعالم 東京大学に行く 北京大学 한국어 테스트 서울대학교 한글-테스트 café')
 
 statement ok
 PRAGMA create_fts_index('unicode_docs', 'id', 'body', tokenizer='opensearch_standard', stemmer='none', stopwords='none')
@@ -58,6 +58,48 @@ FROM fts_main_unicode_docs.dict
 WHERE term IN ('東', '京', '大', '学', 'に', '行', 'く', '北', '한국어', '테스트')
 ----
 10
+
+query I
+SELECT count(*)
+FROM fts_main_unicode_docs.dict
+WHERE term = '서울대학교'
+----
+1
+
+query I
+SELECT count(*)
+FROM fts_main_unicode_docs.dict
+WHERE term = '서울'
+----
+0
+
+query I
+SELECT count(*)
+FROM fts_main_unicode_docs.dict
+WHERE term = '한글'
+----
+1
+
+query I
+SELECT count(*)
+FROM fts_main_unicode_docs.dict
+WHERE term = 'café'
+----
+1
+
+query I
+SELECT count(*)
+FROM fts_main_unicode_docs.dict
+WHERE term = 'cafe'
+----
+0
+
+statement ok
+PRAGMA create_fts_index('unicode_docs', 'id', 'body', tokenizer='opensearch_standard', stemmer='none', stopwords='none', strip_accents=false, overwrite=true)
+
+statement error
+PRAGMA create_fts_index('unicode_docs', 'id', 'body', tokenizer='opensearch_standard', stemmer='none', stopwords='none', strip_accents=true, overwrite=true)
+----
 
 query T
 SELECT token


### PR DESCRIPTION
Part of: https://github.com/duckdblabs/duckdb-internal/issues/9855

Couple of points in this PR: 
- Reject `strip_accents` when the `tokenizer` mode is set to `opensearch_standard`
- Decomposed combining marks are now preserved inside tokens (these would previously cause a split)


A follow-up should work on:
- Improved word-boundary implementation using the ICU `BreakIterator`, but at the moment this is not compiled in the ICU extension. 
- Opensearch-style ASCII folding (e.g. Straße --> strasse)
- Support for `max_token_length` 

If we want even more compatibility, we should also look at the stemmer and stopword list to make it match with OpenSearch/Lucene