### PR TITLE
Make FTS tests compatible with autoloading

### DIFF
--- a/test/sql/fts/test_boolean_query.test
+++ b/test/sql/fts/test_boolean_query.test
@@ -11,6 +11,9 @@ require json
 require no_alternative_verify
 
 statement ok
+SELECT json_valid('{}')
+
+statement ok
 CREATE TABLE boolean_docs(id VARCHAR NOT NULL, title VARCHAR, body VARCHAR)
 
 statement ok

--- a/test/sql/fts/test_layered_search.test
+++ b/test/sql/fts/test_layered_search.test
@@ -531,8 +531,10 @@ FROM fts_main_autocomplete_docs.search_layered_bm25(
 doc2
 
 # Existing layered indexes can install the structured macros after JSON loads.
+require json
+
 statement ok
-LOAD json
+SELECT json_valid('{}')
 
 statement ok
 PRAGMA create_fts_boolean_query_macros('documents')


### PR DESCRIPTION
I explicitly load JSON through its autoload path so the FTS structured-query tests pass in DuckDB's autoload-only configuration.