### PR TITLE
Add a canonical FTS analyzer token stream

### DIFF
--- a/.github/regression/fts_analyzer.csv
+++ b/.github/regression/fts_analyzer.csv
@@ -1,0 +1,2 @@
+benchmark/fts/layered_autocomplete/smoke/analyze_regex.benchmark
+benchmark/fts/layered_autocomplete/smoke/analyze_opensearch.benchmark

--- a/.github/regression/fts_analyzer_haystack.csv
+++ b/.github/regression/fts_analyzer_haystack.csv
@@ -1,0 +1,2 @@
+benchmark/fts/layered_autocomplete/haystack/analyze_regex.benchmark
+benchmark/fts/layered_autocomplete/haystack/analyze_opensearch.benchmark

--- a/.github/regression/fts_layered.csv
+++ b/.github/regression/fts_layered.csv
@@ -1,4 +1,6 @@
 benchmark/fts/layered_autocomplete/smoke/index_create.benchmark
+benchmark/fts/layered_autocomplete/smoke/index_create_base_regex.benchmark
+benchmark/fts/layered_autocomplete/smoke/index_create_layered_opensearch.benchmark
 benchmark/fts/layered_autocomplete/smoke/layered_exact.benchmark
 benchmark/fts/layered_autocomplete/smoke/layered_prefix.benchmark
 benchmark/fts/layered_autocomplete/smoke/layered_substring.benchmark

--- a/.github/regression/fts_layered_haystack.csv
+++ b/.github/regression/fts_layered_haystack.csv
@@ -1,4 +1,6 @@
 benchmark/fts/layered_autocomplete/haystack/index_create.benchmark
+benchmark/fts/layered_autocomplete/haystack/index_create_base_regex.benchmark
+benchmark/fts/layered_autocomplete/haystack/index_create_layered_opensearch.benchmark
 benchmark/fts/layered_autocomplete/haystack/layered_exact.benchmark
 benchmark/fts/layered_autocomplete/haystack/layered_prefix.benchmark
 benchmark/fts/layered_autocomplete/haystack/layered_substring.benchmark

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -142,6 +142,7 @@ jobs:
               echo "FIELD_SCORING_BENCHMARKS=.github/regression/fts_field_scoring_haystack.csv"
               echo "BOOLEAN_BENCHMARKS=.github/regression/fts_boolean_haystack.csv"
               echo "PHRASE_BENCHMARKS=.github/regression/fts_phrase_haystack.csv"
+              echo "ANALYZER_BENCHMARKS=.github/regression/fts_analyzer_haystack.csv"
               echo "FOOTPRINT_ROWS=1000000"
               echo "BENCHMARK_BUDGET_SECONDS=3600"
             } >> "$GITHUB_ENV"
@@ -152,6 +153,7 @@ jobs:
               echo "FIELD_SCORING_BENCHMARKS=.github/regression/fts_field_scoring.csv"
               echo "BOOLEAN_BENCHMARKS=.github/regression/fts_boolean.csv"
               echo "PHRASE_BENCHMARKS=.github/regression/fts_phrase.csv"
+              echo "ANALYZER_BENCHMARKS=.github/regression/fts_analyzer.csv"
               echo "FOOTPRINT_ROWS=50000"
               echo "BENCHMARK_BUDGET_SECONDS=300"
             } >> "$GITHUB_ENV"
@@ -178,24 +180,22 @@ jobs:
               --verbose 2>&1 | tee layered-regression.log
 
             python3 duckdb/scripts/regression/test_runner.py \
-              --old "$NEW_RUNNER" \
+              --old "$OLD_RUNNER" \
               --new "$NEW_RUNNER" \
               --benchmarks "$AUTOCOMPLETE_BENCHMARKS" \
               --root-dir . \
               --threads 2 \
               --clear-benchmark-cache \
-              --nofail \
-              --verbose 2>&1 | tee autocomplete-smoke.log
+              --verbose 2>&1 | tee autocomplete-regression.log
 
             python3 duckdb/scripts/regression/test_runner.py \
-              --old "$NEW_RUNNER" \
+              --old "$OLD_RUNNER" \
               --new "$NEW_RUNNER" \
               --benchmarks "$FIELD_SCORING_BENCHMARKS" \
               --root-dir . \
               --threads 2 \
               --clear-benchmark-cache \
-              --nofail \
-              --verbose 2>&1 | tee field-scoring-smoke.log
+              --verbose 2>&1 | tee field-scoring-regression.log
 
             python3 duckdb/scripts/regression/test_runner.py \
               --old "$OLD_RUNNER" \
@@ -207,18 +207,27 @@ jobs:
               --verbose 2>&1 | tee boolean-regression.log
 
             python3 duckdb/scripts/regression/test_runner.py \
-              --old "$NEW_RUNNER" \
+              --old "$OLD_RUNNER" \
               --new "$NEW_RUNNER" \
               --benchmarks "$PHRASE_BENCHMARKS" \
               --root-dir . \
               --threads 2 \
               --clear-benchmark-cache \
+              --verbose 2>&1 | tee phrase-regression.log
+
+            python3 duckdb/scripts/regression/test_runner.py \
+              --old "$NEW_RUNNER" \
+              --new "$NEW_RUNNER" \
+              --benchmarks "$ANALYZER_BENCHMARKS" \
+              --root-dir . \
+              --threads 2 \
+              --clear-benchmark-cache \
               --nofail \
-              --verbose 2>&1 | tee phrase-smoke.log
+              --verbose 2>&1 | tee analyzer-smoke.log
           }
 
           export -f run_benchmarks
-          export OLD_RUNNER NEW_RUNNER LAYERED_BENCHMARKS AUTOCOMPLETE_BENCHMARKS FIELD_SCORING_BENCHMARKS BOOLEAN_BENCHMARKS PHRASE_BENCHMARKS
+          export OLD_RUNNER NEW_RUNNER LAYERED_BENCHMARKS AUTOCOMPLETE_BENCHMARKS FIELD_SCORING_BENCHMARKS BOOLEAN_BENCHMARKS PHRASE_BENCHMARKS ANALYZER_BENCHMARKS
           timeout "${BENCHMARK_BUDGET_SECONDS}s" bash -c run_benchmarks
 
       - name: Report positional index footprint
@@ -238,21 +247,25 @@ jobs:
             echo '```text'
             test ! -f layered-regression.log || cat layered-regression.log
             echo '```'
-            echo '## FTS autocomplete smoke'
+            echo '## FTS autocomplete regression'
             echo '```text'
-            test ! -f autocomplete-smoke.log || cat autocomplete-smoke.log
+            test ! -f autocomplete-regression.log || cat autocomplete-regression.log
             echo '```'
-            echo '## FTS field-scoring smoke'
+            echo '## FTS field-scoring regression'
             echo '```text'
-            test ! -f field-scoring-smoke.log || cat field-scoring-smoke.log
+            test ! -f field-scoring-regression.log || cat field-scoring-regression.log
             echo '```'
             echo '## FTS Boolean-query regression'
             echo '```text'
             test ! -f boolean-regression.log || cat boolean-regression.log
             echo '```'
-            echo '## FTS phrase-query smoke'
+            echo '## FTS phrase-query regression'
             echo '```text'
-            test ! -f phrase-smoke.log || cat phrase-smoke.log
+            test ! -f phrase-regression.log || cat phrase-regression.log
+            echo '```'
+            echo '## FTS analyzer smoke'
+            echo '```text'
+            test ! -f analyzer-smoke.log || cat analyzer-smoke.log
             echo '```'
             echo '## FTS positional index footprint'
             echo '```text'
@@ -267,9 +280,10 @@ jobs:
           name: fts-regression-logs-${{ github.run_attempt }}
           path: |
             layered-regression.log
-            autocomplete-smoke.log
-            field-scoring-smoke.log
+            autocomplete-regression.log
+            field-scoring-regression.log
             boolean-regression.log
-            phrase-smoke.log
+            phrase-regression.log
+            analyzer-smoke.log
             phrase-footprint.log
           if-no-files-found: ignore

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ set(FTS_SQL_ASSETS
     "ENGLISH_STOPWORDS|src/sql/index/english_stopwords.sql"
     "IMPORT_STOPWORDS|src/sql/index/import_stopwords.sql"
     "TOKENIZE_MACRO|src/sql/index/tokenize_macro.sql"
+    "ANALYZE_TOKEN_STREAM|src/sql/index/analyze_token_stream.sql"
+    "ANALYZE_TEXT_MACRO|src/sql/index/analyze_text_macro.sql"
     "INDEX_TABLES|src/sql/index/index_tables.sql"
     "TOKENIZE_FIELD|src/sql/index/tokenize_field.sql"
     "TOKENIZE_POSITIONAL_FIELD|src/sql/index/tokenize_positional_field.sql"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ LOAD fts;
 
 ## Usage
 
-The extension adds two `PRAGMA` statements to DuckDB: one to create, and one to drop an index. Additionally, a scalar macro `stem` is added, which is used internally by the extension.
+The extension adds two `PRAGMA` statements to DuckDB: one to create, and one to drop an index. Additionally, a scalar macro `stem` is added, which is used internally by the extension. Each index schema also contains search macros and an `analyze_text` table macro configured for that index.
 
 ### `PRAGMA create_fts_index`
 
@@ -77,6 +77,35 @@ with `overwrite = true` performs the same cleanup before building the new index.
 | Name | Type | Description |
 |:--|:--|:-----------|
 | `input_table` | `VARCHAR` | Qualified name of input table, e.g., `'table_name'` or `'main.table_name'` |
+
+### Analyzer Inspection
+
+Every generated FTS schema exposes the analyzer used by that index as a table
+macro:
+
+```sql
+SELECT *
+FROM fts_main_documents.analyze_text('The running foxes')
+ORDER BY position;
+```
+
+The result contains the normalized unstemmed `raw_term`, final indexed `term`,
+one-based absolute `position`, `position_increment`, `position_length`,
+`start_offset`, `end_offset`, and `token_type`. Empty tokenizer output is
+removed before positions are assigned. Stopwords are removed afterward, so
+leading and internal stopwords remain visible as position gaps.
+
+Current analyzers use a position length of one and the token type `word`.
+Offsets are reserved as nullable, half-open, zero-based UTF-8 byte offsets into
+the original input. They are currently `NULL` because normalization prevents
+the regex and OpenSearch-compatible tokenizers from mapping every token
+reliably back to the original string.
+
+`analyze_text` uses the same generated analyzer definition as bulk indexing,
+incremental maintenance, and query analysis. The lower-level list-returning
+`tokenize` macro remains available for compatibility, but it does not apply
+stopword removal or stemming. Analyzer contract changes are versioned in
+`index_metadata` and require dropping and recreating an existing index.
 
 ### `match_bm25` Function
 

--- a/benchmark/fts/layered_autocomplete/haystack/analyze_opensearch.benchmark
+++ b/benchmark/fts/layered_autocomplete/haystack/analyze_opensearch.benchmark
@@ -1,0 +1,4 @@
+template benchmark/fts/layered_autocomplete/templates/analyze_text.benchmark.in
+display_name=FTS OpenSearch analyzer inspection (1M)
+rows=1000000
+tokenizer=opensearch_standard

--- a/benchmark/fts/layered_autocomplete/haystack/analyze_regex.benchmark
+++ b/benchmark/fts/layered_autocomplete/haystack/analyze_regex.benchmark
@@ -1,0 +1,4 @@
+template benchmark/fts/layered_autocomplete/templates/analyze_text.benchmark.in
+display_name=FTS regex analyzer inspection (1M)
+rows=1000000
+tokenizer=regex

--- a/benchmark/fts/layered_autocomplete/haystack/index_create_base_regex.benchmark
+++ b/benchmark/fts/layered_autocomplete/haystack/index_create_base_regex.benchmark
@@ -1,6 +1,6 @@
 template benchmark/fts/layered_autocomplete/templates/index_create.benchmark.in
-display_name=FTS layered index creation (1M)
+display_name=FTS base regex index creation (1M)
 rows=1000000
 tokenizer=regex
-layered_search=true
+layered_search=false
 incremental=true

--- a/benchmark/fts/layered_autocomplete/haystack/index_create_layered_opensearch.benchmark
+++ b/benchmark/fts/layered_autocomplete/haystack/index_create_layered_opensearch.benchmark
@@ -1,6 +1,6 @@
 template benchmark/fts/layered_autocomplete/templates/index_create.benchmark.in
-display_name=FTS layered index creation (1M)
+display_name=FTS layered OpenSearch index creation (1M)
 rows=1000000
-tokenizer=regex
+tokenizer=opensearch_standard
 layered_search=true
 incremental=true

--- a/benchmark/fts/layered_autocomplete/smoke/analyze_opensearch.benchmark
+++ b/benchmark/fts/layered_autocomplete/smoke/analyze_opensearch.benchmark
@@ -1,0 +1,4 @@
+template benchmark/fts/layered_autocomplete/templates/analyze_text.benchmark.in
+display_name=FTS OpenSearch analyzer inspection (50K)
+rows=50000
+tokenizer=opensearch_standard

--- a/benchmark/fts/layered_autocomplete/smoke/analyze_regex.benchmark
+++ b/benchmark/fts/layered_autocomplete/smoke/analyze_regex.benchmark
@@ -1,0 +1,4 @@
+template benchmark/fts/layered_autocomplete/templates/analyze_text.benchmark.in
+display_name=FTS regex analyzer inspection (50K)
+rows=50000
+tokenizer=regex

--- a/benchmark/fts/layered_autocomplete/smoke/index_create.benchmark
+++ b/benchmark/fts/layered_autocomplete/smoke/index_create.benchmark
@@ -1,3 +1,6 @@
 template benchmark/fts/layered_autocomplete/templates/index_create.benchmark.in
 display_name=FTS layered index creation (50K)
 rows=50000
+tokenizer=regex
+layered_search=true
+incremental=true

--- a/benchmark/fts/layered_autocomplete/smoke/index_create_base_regex.benchmark
+++ b/benchmark/fts/layered_autocomplete/smoke/index_create_base_regex.benchmark
@@ -1,6 +1,6 @@
 template benchmark/fts/layered_autocomplete/templates/index_create.benchmark.in
-display_name=FTS layered index creation (1M)
-rows=1000000
+display_name=FTS base regex index creation (50K)
+rows=50000
 tokenizer=regex
-layered_search=true
+layered_search=false
 incremental=true

--- a/benchmark/fts/layered_autocomplete/smoke/index_create_layered_opensearch.benchmark
+++ b/benchmark/fts/layered_autocomplete/smoke/index_create_layered_opensearch.benchmark
@@ -1,6 +1,6 @@
 template benchmark/fts/layered_autocomplete/templates/index_create.benchmark.in
-display_name=FTS layered index creation (1M)
-rows=1000000
-tokenizer=regex
+display_name=FTS layered OpenSearch index creation (50K)
+rows=50000
+tokenizer=opensearch_standard
 layered_search=true
 incremental=true

--- a/benchmark/fts/layered_autocomplete/templates/analyze_text.benchmark.in
+++ b/benchmark/fts/layered_autocomplete/templates/analyze_text.benchmark.in
@@ -1,0 +1,43 @@
+name ${display_name}
+group fts
+subgroup analyzer
+
+require fts
+
+init
+CREATE TABLE documents(id VARCHAR NOT NULL, body VARCHAR);
+INSERT INTO documents
+SELECT 'doc' || lpad(i::VARCHAR, 12, '0') AS id,
+       'workspace item search benchmark running foxes alpha the beta ' ||
+           substr(md5(i::VARCHAR), 1, 16) AS body
+FROM range(${rows}) AS source(i);
+
+load
+PRAGMA create_fts_index(
+    'documents',
+    'id',
+    'body',
+    stemmer='porter',
+    tokenizer='${tokenizer}',
+    stopwords='english'
+);
+
+assert II
+SELECT count(*) > ${rows},
+       sum(position_increment) > 0
+FROM documents
+CROSS JOIN LATERAL fts_main_documents.analyze_text(documents.body)
+----
+true	true
+
+run
+SELECT count(*),
+       sum(position),
+       sum(position_increment),
+       sum(position_length),
+       count(raw_term),
+       count(term),
+       count(start_offset),
+       count(end_offset)
+FROM documents
+CROSS JOIN LATERAL fts_main_documents.analyze_text(documents.body);

--- a/benchmark/fts/layered_autocomplete/templates/index_create.benchmark.in
+++ b/benchmark/fts/layered_autocomplete/templates/index_create.benchmark.in
@@ -26,7 +26,17 @@ SELECT count(*) = ${rows} FROM documents
 true
 
 run
-PRAGMA create_fts_index('documents', 'id', 'title', 'body', stemmer='porter', stopwords='none', layered_search=true, incremental=true)
+PRAGMA create_fts_index(
+    'documents',
+    'id',
+    'title',
+    'body',
+    stemmer='porter',
+    tokenizer='${tokenizer}',
+    stopwords='none',
+    layered_search=${layered_search},
+    incremental=${incremental}
+)
 
 cleanup
 PRAGMA drop_fts_index('documents');

--- a/src/fts_index_builder.cpp
+++ b/src/fts_index_builder.cpp
@@ -91,15 +91,13 @@ static string TokenizeMacroScript(const QualifiedName &qname,
 }
 
 static string AnalyzeTextMacroScript(const QualifiedName &qname,
-                                     const string &stemmer,
-                                     bool filter_stopwords) {
+                                     const FTSAnalyzerConfig &config) {
   return RenderSQLTemplate(
       fts_sql::ANALYZE_TEXT_MACRO,
       {{"fts_schema", GetFTSSchemaArgument(qname)},
        {"analyzed_tokens",
         SQLTemplateArgument::TrustedSQL(RenderAnalyzeTokenStream(
-            qname, stemmer, ",\n       tokenized.position",
-            filter_stopwords))}});
+            qname, config, AnalyzeTokenStreamProjection::POSITION))}});
 }
 
 static string IndexTablesScript(const QualifiedName &qname,
@@ -108,7 +106,7 @@ static string IndexTablesScript(const QualifiedName &qname,
                                 const string &build_terms_table,
                                 const string &build_dict_table,
                                 const string &build_raw_dict_table,
-                                const string &stemmer, bool filter_stopwords,
+                                const FTSAnalyzerConfig &analyzer_config,
                                 bool cluster_terms, bool layered_search) {
   vector<string> field_values;
   vector<string> tokenize_fields;
@@ -168,12 +166,10 @@ static string IndexTablesScript(const QualifiedName &qname,
                                   tokenize_fields, " UNION ALL "))},
        {"analyzed_tokens",
         SQLTemplateArgument::TrustedSQL(RenderAnalyzeTokenStream(
-            qname, stemmer,
-            layered_search ? ",\n       tokenized.docid,\n       "
-                             "tokenized.fieldid,\n       tokenized.position"
-                           : ",\n       tokenized.docid,\n       "
-                             "tokenized.fieldid",
-            filter_stopwords))},
+            qname, analyzer_config,
+            layered_search
+                ? AnalyzeTokenStreamProjection::DOCID_FIELDID_POSITION
+                : AnalyzeTokenStreamProjection::DOCID_FIELDID))},
        {"raw_term_output",
         SQLTemplateArgument::TrustedSQL(
             layered_search ? "stemmed_stopped.raw_term," : "")},
@@ -277,13 +273,13 @@ static string FieldScoringScoreCTEs(const QualifiedName &qname) {
 }
 
 static string MatchMacroScript(const QualifiedName &qname,
-                               const string &stemmer, bool filter_stopwords) {
+                               const FTSAnalyzerConfig &config) {
   return RenderSQLTemplate(
       fts_sql::MATCH_BM25,
       {{"fts_schema", GetFTSSchemaArgument(qname)},
        {"analyzed_tokens",
-        SQLTemplateArgument::TrustedSQL(
-            RenderAnalyzeTokenStream(qname, stemmer, "", filter_stopwords))},
+        SQLTemplateArgument::TrustedSQL(RenderAnalyzeTokenStream(
+            qname, config, AnalyzeTokenStreamProjection::NONE))},
        {"field_scoring_config_ctes",
         SQLTemplateArgument::TrustedSQL(FieldScoringConfigCTEs(qname))},
        {"field_scoring_score_ctes",
@@ -291,37 +287,36 @@ static string MatchMacroScript(const QualifiedName &qname,
 }
 
 static string LayeredSearchTableMacroScript(const QualifiedName &qname,
-                                            const string &stemmer,
-                                            bool filter_stopwords) {
+                                            const FTSAnalyzerConfig &config) {
   auto is_final_token =
-      filter_stopwords
+      config.filter_stopwords
           ? ",\n           generate_subscripts(tokens, 1) = len(tokens) "
             "AS is_final_token"
           : "";
   auto phrase_prefix_stopword_token =
-      filter_stopwords ? "UNION ALL\n"
-                         "    SELECT tokenized.raw_term AS raw_token,\n"
-                         "           NULL::VARCHAR AS term,\n"
-                         "           tokenized.token_position\n"
-                         "    FROM tokenized\n"
-                         "    CROSS JOIN params\n"
-                         "    WHERE params.query_mode = 'phrase_prefix'\n"
-                         "      AND tokenized.is_final_token\n"
-                         "      AND tokenized.raw_term IN (\n"
-                         "          SELECT sw\n"
-                         "          FROM " +
-                             GetFTSSchema(qname) +
-                             ".stopwords\n"
-                             "      )"
-                       : "";
+      config.filter_stopwords
+          ? "UNION ALL\n"
+            "    SELECT tokenized.raw_term AS raw_token,\n"
+            "           NULL::VARCHAR AS term,\n"
+            "           tokenized.token_position\n"
+            "    FROM tokenized\n"
+            "    CROSS JOIN params\n"
+            "    WHERE params.query_mode = 'phrase_prefix'\n"
+            "      AND tokenized.is_final_token\n"
+            "      AND tokenized.raw_term IN (\n"
+            "          SELECT sw\n"
+            "          FROM " +
+                GetFTSSchema(qname) +
+                ".stopwords\n"
+                "      )"
+          : "";
   return RenderSQLTemplate(
       fts_sql::SEARCH_LAYERED_BM25,
       {{"fts_schema", GetFTSSchemaArgument(qname)},
        {"is_final_token", SQLTemplateArgument::TrustedSQL(is_final_token)},
        {"analyzed_tokens",
         SQLTemplateArgument::TrustedSQL(RenderAnalyzeTokenStream(
-            qname, stemmer, ",\n       tokenized.token_position",
-            filter_stopwords))},
+            qname, config, AnalyzeTokenStreamProjection::TOKEN_POSITION))},
        {"phrase_prefix_stopword_token",
         SQLTemplateArgument::TrustedSQL(phrase_prefix_stopword_token)},
        {"field_scoring_config_ctes",
@@ -357,12 +352,10 @@ static string StructuredLayeredSearchMacroScript(const QualifiedName &qname) {
 }
 
 static string LayeredSearchMacroScript(const QualifiedName &qname,
-                                       const string &stemmer,
-                                       bool filter_stopwords,
+                                       const FTSAnalyzerConfig &analyzer_config,
                                        bool include_structured_queries) {
-  auto result =
-      LayeredSearchTableMacroScript(qname, stemmer, filter_stopwords) +
-      LayeredMatchMacroScript(qname);
+  auto result = LayeredSearchTableMacroScript(qname, analyzer_config) +
+                LayeredMatchMacroScript(qname);
   if (include_structured_queries) {
     result += StructuredLayeredSearchMacroScript(qname);
   }
@@ -372,6 +365,10 @@ static string LayeredSearchMacroScript(const QualifiedName &qname,
 string FTSIndexBuilder::Create(const FTSIndexConfig &config,
                                bool drop_existing_triggers) {
   auto &qname = config.input_table;
+  FTSAnalyzerConfig analyzer_config;
+  analyzer_config.stemmer = config.stemmer;
+  analyzer_config.filter_stopwords =
+      config.stopwords_mode != FTSStopwordsMode::NONE;
   string result;
   if (drop_existing_triggers) {
     result += FTSIndexMaintenance::DropTriggers(qname);
@@ -380,24 +377,25 @@ string FTSIndexBuilder::Create(const FTSIndexConfig &config,
   result += StopwordsScript(config);
   result += TokenizeMacroScript(qname, config.tokenizer, config.ignore,
                                 config.strip_accents, config.lower);
-  auto filter_stopwords = config.stopwords_mode != FTSStopwordsMode::NONE;
-  result += AnalyzeTextMacroScript(qname, config.stemmer, filter_stopwords);
+  result += AnalyzeTextMacroScript(qname, analyzer_config);
   result += IndexTablesScript(
       qname, config.input_id, config.input_values, GetFTSBuildTermsTable(qname),
       GetFTSBuildDictTable(qname), GetFTSBuildRawDictTable(qname),
-      config.stemmer, filter_stopwords, config.cluster_terms,
-      config.layered_search);
+      analyzer_config, config.cluster_terms, config.layered_search);
   result += IndexMetadataScript(config);
-  result += MatchMacroScript(qname, config.stemmer, filter_stopwords);
+  result += MatchMacroScript(qname, analyzer_config);
   if (config.layered_search) {
     result += LayeredSidecarScript(qname);
-    result += LayeredSearchMacroScript(qname, config.stemmer, filter_stopwords,
+    result += LayeredSearchMacroScript(qname, analyzer_config,
                                        config.structured_queries);
   }
   if (config.incremental) {
+    FTSIndexMaintenanceConfig maintenance_config;
+    maintenance_config.analyzer = analyzer_config;
+    maintenance_config.cluster_terms = config.cluster_terms;
+    maintenance_config.layered_search = config.layered_search;
     result += FTSIndexMaintenance::Create(
-        qname, config.input_id, config.input_values, config.stemmer,
-        filter_stopwords, config.cluster_terms, config.layered_search);
+        qname, config.input_id, config.input_values, maintenance_config);
   }
   return result;
 }

--- a/src/fts_index_builder.cpp
+++ b/src/fts_index_builder.cpp
@@ -10,7 +10,8 @@
 
 namespace duckdb {
 
-static constexpr int64_t FTS_INDEX_FORMAT_VERSION = 2;
+static constexpr int64_t FTS_INDEX_FORMAT_VERSION = 3;
+static constexpr int64_t FTS_ANALYZER_VERSION = 1;
 
 static string SchemaSetupScript(const QualifiedName &qname) {
   return RenderSQLTemplate(fts_sql::SCHEMA_SETUP,
@@ -34,6 +35,8 @@ static void AppendAnalyzerConfigValue(string &result, const string &name,
 
 static string AnalyzerConfigBase(const FTSIndexConfig &config) {
   string result;
+  AppendAnalyzerConfigValue(result, "version",
+                            std::to_string(FTS_ANALYZER_VERSION));
   AppendAnalyzerConfigValue(result, "stemmer", config.stemmer);
   AppendAnalyzerConfigValue(result, "tokenizer", config.tokenizer);
   AppendAnalyzerConfigValue(result, "ignore", config.ignore);
@@ -87,20 +90,26 @@ static string TokenizeMacroScript(const QualifiedName &qname,
        {"token_expression", SQLTemplateArgument::TrustedSQL(expr)}});
 }
 
-static string IndexTablesScript(
-    const QualifiedName &qname, const string &input_id,
-    const vector<string> &input_values, const string &stemmer,
-    FTSStopwordsMode stopwords_mode, const string &build_terms_table,
-    const string &build_dict_table, const string &build_raw_dict_table,
-    bool cluster_terms, bool layered_search) {
-  string term_expression =
-      stemmer == "none" ? "t.w"
-                        : "stem(t.w, " + SQLString::ToString(stemmer) + ")";
-  string stopwords_filter = stopwords_mode == FTSStopwordsMode::NONE
-                                ? string("")
-                                : "AND t.w NOT IN (SELECT sw FROM " +
-                                      GetFTSSchema(qname) + ".stopwords)";
+static string AnalyzeTextMacroScript(const QualifiedName &qname,
+                                     const string &stemmer,
+                                     bool filter_stopwords) {
+  return RenderSQLTemplate(
+      fts_sql::ANALYZE_TEXT_MACRO,
+      {{"fts_schema", GetFTSSchemaArgument(qname)},
+       {"analyzed_tokens",
+        SQLTemplateArgument::TrustedSQL(RenderAnalyzeTokenStream(
+            qname, stemmer, ",\n       tokenized.position",
+            filter_stopwords))}});
+}
 
+static string IndexTablesScript(const QualifiedName &qname,
+                                const string &input_id,
+                                const vector<string> &input_values,
+                                const string &build_terms_table,
+                                const string &build_dict_table,
+                                const string &build_raw_dict_table,
+                                const string &stemmer, bool filter_stopwords,
+                                bool cluster_terms, bool layered_search) {
   vector<string> field_values;
   vector<string> tokenize_fields;
   for (idx_t i = 0; i < input_values.size(); i++) {
@@ -157,18 +166,20 @@ static string IndexTablesScript(
         SQLTemplateArgument::TrustedSQL(build_raw_dict_table)},
        {"union_fields_query", SQLTemplateArgument::TrustedSQL(StringUtil::Join(
                                   tokenize_fields, " UNION ALL "))},
-       {"term_expression", SQLTemplateArgument::TrustedSQL(term_expression)},
-       {"raw_term_select", SQLTemplateArgument::TrustedSQL(
-                               layered_search ? "t.w AS raw_term," : "")},
-       {"stopwords_filter", SQLTemplateArgument::TrustedSQL(stopwords_filter)},
+       {"analyzed_tokens",
+        SQLTemplateArgument::TrustedSQL(RenderAnalyzeTokenStream(
+            qname, stemmer,
+            layered_search ? ",\n       tokenized.docid,\n       "
+                             "tokenized.fieldid,\n       tokenized.position"
+                           : ",\n       tokenized.docid,\n       "
+                             "tokenized.fieldid",
+            filter_stopwords))},
        {"raw_term_output",
-        SQLTemplateArgument::TrustedSQL(layered_search ? "ss.raw_term," : "")},
-       {"build_position_select",
         SQLTemplateArgument::TrustedSQL(
-            layered_search ? ",\n           t.position AS position" : "")},
+            layered_search ? "stemmed_stopped.raw_term," : "")},
        {"build_position_output",
-        SQLTemplateArgument::TrustedSQL(layered_search ? ",\n       ss.position"
-                                                       : "")},
+        SQLTemplateArgument::TrustedSQL(
+            layered_search ? ",\n       stemmed_stopped.position" : "")},
        {"field_length_aggregates",
         SQLTemplateArgument::TrustedSQL(
             FieldLengthAggregateList(input_values.size()))},
@@ -204,6 +215,7 @@ static string IndexMetadataScript(const FTSIndexConfig &config) {
       {{"fts_schema", GetFTSSchemaArgument(config.input_table)},
        {"format_version",
         SQLTemplateArgument::Integer(FTS_INDEX_FORMAT_VERSION)},
+       {"analyzer_version", SQLTemplateArgument::Integer(FTS_ANALYZER_VERSION)},
        {"incremental", SQLTemplateArgument::Boolean(config.incremental)},
        {"cluster_terms", SQLTemplateArgument::Boolean(config.cluster_terms)},
        {"layered_search", SQLTemplateArgument::Boolean(config.layered_search)},
@@ -265,11 +277,13 @@ static string FieldScoringScoreCTEs(const QualifiedName &qname) {
 }
 
 static string MatchMacroScript(const QualifiedName &qname,
-                               const string &stemmer) {
+                               const string &stemmer, bool filter_stopwords) {
   return RenderSQLTemplate(
       fts_sql::MATCH_BM25,
       {{"fts_schema", GetFTSSchemaArgument(qname)},
-       {"stemmer", SQLTemplateArgument::StringLiteral(stemmer)},
+       {"analyzed_tokens",
+        SQLTemplateArgument::TrustedSQL(
+            RenderAnalyzeTokenStream(qname, stemmer, "", filter_stopwords))},
        {"field_scoring_config_ctes",
         SQLTemplateArgument::TrustedSQL(FieldScoringConfigCTEs(qname))},
        {"field_scoring_score_ctes",
@@ -277,11 +291,39 @@ static string MatchMacroScript(const QualifiedName &qname,
 }
 
 static string LayeredSearchTableMacroScript(const QualifiedName &qname,
-                                            const string &stemmer) {
+                                            const string &stemmer,
+                                            bool filter_stopwords) {
+  auto is_final_token =
+      filter_stopwords
+          ? ",\n           generate_subscripts(tokens, 1) = len(tokens) "
+            "AS is_final_token"
+          : "";
+  auto phrase_prefix_stopword_token =
+      filter_stopwords ? "UNION ALL\n"
+                         "    SELECT tokenized.raw_term AS raw_token,\n"
+                         "           NULL::VARCHAR AS term,\n"
+                         "           tokenized.token_position\n"
+                         "    FROM tokenized\n"
+                         "    CROSS JOIN params\n"
+                         "    WHERE params.query_mode = 'phrase_prefix'\n"
+                         "      AND tokenized.is_final_token\n"
+                         "      AND tokenized.raw_term IN (\n"
+                         "          SELECT sw\n"
+                         "          FROM " +
+                             GetFTSSchema(qname) +
+                             ".stopwords\n"
+                             "      )"
+                       : "";
   return RenderSQLTemplate(
       fts_sql::SEARCH_LAYERED_BM25,
       {{"fts_schema", GetFTSSchemaArgument(qname)},
-       {"stemmer", SQLTemplateArgument::StringLiteral(stemmer)},
+       {"is_final_token", SQLTemplateArgument::TrustedSQL(is_final_token)},
+       {"analyzed_tokens",
+        SQLTemplateArgument::TrustedSQL(RenderAnalyzeTokenStream(
+            qname, stemmer, ",\n       tokenized.token_position",
+            filter_stopwords))},
+       {"phrase_prefix_stopword_token",
+        SQLTemplateArgument::TrustedSQL(phrase_prefix_stopword_token)},
        {"field_scoring_config_ctes",
         SQLTemplateArgument::TrustedSQL(FieldScoringConfigCTEs(qname))},
        {"field_scoring_score_ctes",
@@ -316,9 +358,11 @@ static string StructuredLayeredSearchMacroScript(const QualifiedName &qname) {
 
 static string LayeredSearchMacroScript(const QualifiedName &qname,
                                        const string &stemmer,
+                                       bool filter_stopwords,
                                        bool include_structured_queries) {
-  auto result = LayeredSearchTableMacroScript(qname, stemmer) +
-                LayeredMatchMacroScript(qname);
+  auto result =
+      LayeredSearchTableMacroScript(qname, stemmer, filter_stopwords) +
+      LayeredMatchMacroScript(qname);
   if (include_structured_queries) {
     result += StructuredLayeredSearchMacroScript(qname);
   }
@@ -336,22 +380,24 @@ string FTSIndexBuilder::Create(const FTSIndexConfig &config,
   result += StopwordsScript(config);
   result += TokenizeMacroScript(qname, config.tokenizer, config.ignore,
                                 config.strip_accents, config.lower);
+  auto filter_stopwords = config.stopwords_mode != FTSStopwordsMode::NONE;
+  result += AnalyzeTextMacroScript(qname, config.stemmer, filter_stopwords);
   result += IndexTablesScript(
-      qname, config.input_id, config.input_values, config.stemmer,
-      config.stopwords_mode, GetFTSBuildTermsTable(qname),
+      qname, config.input_id, config.input_values, GetFTSBuildTermsTable(qname),
       GetFTSBuildDictTable(qname), GetFTSBuildRawDictTable(qname),
-      config.cluster_terms, config.layered_search);
+      config.stemmer, filter_stopwords, config.cluster_terms,
+      config.layered_search);
   result += IndexMetadataScript(config);
-  result += MatchMacroScript(qname, config.stemmer);
+  result += MatchMacroScript(qname, config.stemmer, filter_stopwords);
   if (config.layered_search) {
     result += LayeredSidecarScript(qname);
-    result += LayeredSearchMacroScript(qname, config.stemmer,
+    result += LayeredSearchMacroScript(qname, config.stemmer, filter_stopwords,
                                        config.structured_queries);
   }
   if (config.incremental) {
     result += FTSIndexMaintenance::Create(
         qname, config.input_id, config.input_values, config.stemmer,
-        config.cluster_terms, config.layered_search);
+        filter_stopwords, config.cluster_terms, config.layered_search);
   }
   return result;
 }

--- a/src/fts_index_common.cpp
+++ b/src/fts_index_common.cpp
@@ -1,5 +1,7 @@
 #include "fts_index_common.hpp"
 
+#include "fts_sql_assets.hpp"
+
 #include "duckdb/common/sql_identifier.hpp"
 #include "duckdb/common/string_util.hpp"
 
@@ -40,6 +42,30 @@ SQLTemplateArgument GetQualifiedTableArgument(const QualifiedName &qname) {
   parts.push_back(qname.Schema().GetIdentifierName());
   parts.push_back(qname.Name().GetIdentifierName());
   return SQLTemplateArgument::QualifiedIdentifier(parts);
+}
+
+string RenderAnalyzeTokenStream(const QualifiedName &qname,
+                                const string &stemmer,
+                                const string &passthrough,
+                                bool filter_stopwords) {
+  auto term_expression =
+      stemmer == "none"
+          ? "tokenized.raw_term"
+          : "stem(tokenized.raw_term, " + SQLString::ToString(stemmer) + ")";
+  auto stopwords_filter = filter_stopwords
+                              ? "  AND tokenized.raw_term NOT IN (\n"
+                                "      SELECT sw\n"
+                                "      FROM " +
+                                    GetFTSSchema(qname) +
+                                    ".stopwords\n"
+                                    "  )"
+                              : "";
+  return RenderSQLTemplate(
+      fts_sql::ANALYZE_TOKEN_STREAM,
+      {{"term_expression", SQLTemplateArgument::TrustedSQL(term_expression)},
+       {"passthrough", SQLTemplateArgument::TrustedSQL(passthrough)},
+       {"stopwords_filter",
+        SQLTemplateArgument::TrustedSQL(stopwords_filter)}});
 }
 
 vector<string> GetFTSInsertTriggerNames(const QualifiedName &qname) {

--- a/src/fts_index_common.cpp
+++ b/src/fts_index_common.cpp
@@ -2,6 +2,7 @@
 
 #include "fts_sql_assets.hpp"
 
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/sql_identifier.hpp"
 #include "duckdb/common/string_util.hpp"
 
@@ -44,15 +45,32 @@ SQLTemplateArgument GetQualifiedTableArgument(const QualifiedName &qname) {
   return SQLTemplateArgument::QualifiedIdentifier(parts);
 }
 
+static string
+AnalyzeTokenStreamProjectionSQL(AnalyzeTokenStreamProjection projection) {
+  switch (projection) {
+  case AnalyzeTokenStreamProjection::NONE:
+    return "";
+  case AnalyzeTokenStreamProjection::POSITION:
+    return ",\n       tokenized.position";
+  case AnalyzeTokenStreamProjection::DOCID_FIELDID:
+    return ",\n       tokenized.docid,\n       tokenized.fieldid";
+  case AnalyzeTokenStreamProjection::DOCID_FIELDID_POSITION:
+    return ",\n       tokenized.docid,\n       tokenized.fieldid,\n       "
+           "tokenized.position";
+  case AnalyzeTokenStreamProjection::TOKEN_POSITION:
+    return ",\n       tokenized.token_position";
+  }
+  throw InternalException("Unsupported analyzer token stream projection");
+}
+
 string RenderAnalyzeTokenStream(const QualifiedName &qname,
-                                const string &stemmer,
-                                const string &passthrough,
-                                bool filter_stopwords) {
-  auto term_expression =
-      stemmer == "none"
-          ? "tokenized.raw_term"
-          : "stem(tokenized.raw_term, " + SQLString::ToString(stemmer) + ")";
-  auto stopwords_filter = filter_stopwords
+                                const FTSAnalyzerConfig &config,
+                                AnalyzeTokenStreamProjection projection) {
+  auto term_expression = config.stemmer == "none"
+                             ? "tokenized.raw_term"
+                             : "stem(tokenized.raw_term, " +
+                                   SQLString::ToString(config.stemmer) + ")";
+  auto stopwords_filter = config.filter_stopwords
                               ? "  AND tokenized.raw_term NOT IN (\n"
                                 "      SELECT sw\n"
                                 "      FROM " +
@@ -63,7 +81,8 @@ string RenderAnalyzeTokenStream(const QualifiedName &qname,
   return RenderSQLTemplate(
       fts_sql::ANALYZE_TOKEN_STREAM,
       {{"term_expression", SQLTemplateArgument::TrustedSQL(term_expression)},
-       {"passthrough", SQLTemplateArgument::TrustedSQL(passthrough)},
+       {"projected_columns", SQLTemplateArgument::TrustedSQL(
+                                 AnalyzeTokenStreamProjectionSQL(projection))},
        {"stopwords_filter",
         SQLTemplateArgument::TrustedSQL(stopwords_filter)}});
 }

--- a/src/fts_index_maintenance.cpp
+++ b/src/fts_index_maintenance.cpp
@@ -194,7 +194,7 @@ static vector<string> BuildInsertedFieldQueries(
 static string InsertTriggerScript(const QualifiedName &qname,
                                   const string &input_id,
                                   const vector<string> &input_values,
-                                  const string &stemmer, bool filter_stopwords,
+                                  const FTSAnalyzerConfig &analyzer_config,
                                   bool layered_search) {
   vector<string> input_value_selects;
   auto tokenize_fields = BuildInsertedFieldQueries(
@@ -221,12 +221,10 @@ static string InsertTriggerScript(const QualifiedName &qname,
         SQLTemplateArgument::TrustedSQL(union_fields_query)},
        {"analyzed_tokens",
         SQLTemplateArgument::TrustedSQL(RenderAnalyzeTokenStream(
-            qname, stemmer,
-            layered_search ? ",\n       tokenized.docid,\n       "
-                             "tokenized.fieldid,\n       tokenized.position"
-                           : ",\n       tokenized.docid,\n       "
-                             "tokenized.fieldid",
-            filter_stopwords))}});
+            qname, analyzer_config,
+            layered_search
+                ? AnalyzeTokenStreamProjection::DOCID_FIELDID_POSITION
+                : AnalyzeTokenStreamProjection::DOCID_FIELDID))}});
   auto trigger_names = GetFTSInsertTriggerNames(qname);
   auto raw_dict_join =
       layered_search ? "JOIN " + GetFTSSchema(qname) +
@@ -250,9 +248,8 @@ static string InsertTriggerScript(const QualifiedName &qname,
         SQLTemplateArgument::TrustedSQL(union_fields_query)},
        {"analyzed_tokens",
         SQLTemplateArgument::TrustedSQL(RenderAnalyzeTokenStream(
-            qname, stemmer,
-            ",\n       tokenized.docid,\n       tokenized.fieldid",
-            filter_stopwords))},
+            qname, analyzer_config,
+            AnalyzeTokenStreamProjection::DOCID_FIELDID))},
        {"field_length_aggregates",
         SQLTemplateArgument::TrustedSQL(
             FieldLengthAggregateList(input_values.size()))},
@@ -289,11 +286,10 @@ static string InsertTriggerScript(const QualifiedName &qname,
             qname, input_id, input_values.size(), true))}});
 }
 
-static string ClusteredInsertTriggerScript(const QualifiedName &qname,
-                                           const string &input_id,
-                                           const vector<string> &input_values,
-                                           const string &stemmer,
-                                           bool filter_stopwords) {
+static string
+ClusteredInsertTriggerScript(const QualifiedName &qname, const string &input_id,
+                             const vector<string> &input_values,
+                             const FTSAnalyzerConfig &analyzer_config) {
   vector<string> input_value_selects;
   auto tokenize_fields = BuildInsertedFieldQueries(qname, input_values,
                                                    input_value_selects, false);
@@ -319,9 +315,8 @@ static string ClusteredInsertTriggerScript(const QualifiedName &qname,
         SQLTemplateArgument::TrustedSQL(union_fields_query)},
        {"analyzed_tokens",
         SQLTemplateArgument::TrustedSQL(RenderAnalyzeTokenStream(
-            qname, stemmer,
-            ",\n       tokenized.docid,\n       tokenized.fieldid",
-            filter_stopwords))}});
+            qname, analyzer_config,
+            AnalyzeTokenStreamProjection::DOCID_FIELDID))}});
   auto trigger_names = GetFTSClusteredInsertTriggerNames(qname);
   return RenderSQLTemplate(
       fts_sql::CLUSTERED_INSERT_TRIGGERS,
@@ -341,9 +336,8 @@ static string ClusteredInsertTriggerScript(const QualifiedName &qname,
         SQLTemplateArgument::TrustedSQL(union_fields_query)},
        {"analyzed_tokens",
         SQLTemplateArgument::TrustedSQL(RenderAnalyzeTokenStream(
-            qname, stemmer,
-            ",\n       tokenized.docid,\n       tokenized.fieldid",
-            filter_stopwords))},
+            qname, analyzer_config,
+            AnalyzeTokenStreamProjection::DOCID_FIELDID))},
        {"field_length_aggregates",
         SQLTemplateArgument::TrustedSQL(
             FieldLengthAggregateList(input_values.size()))},
@@ -362,7 +356,7 @@ static string ClusteredInsertTriggerScript(const QualifiedName &qname,
 static string DeleteTriggerScript(const QualifiedName &qname,
                                   const string &input_id,
                                   const vector<string> &input_values,
-                                  const string &stemmer, bool filter_stopwords,
+                                  const FTSAnalyzerConfig &analyzer_config,
                                   bool layered_search) {
   vector<string> tokenize_fields;
   for (auto &input_value : input_values) {
@@ -376,8 +370,8 @@ static string DeleteTriggerScript(const QualifiedName &qname,
       {{"union_fields_query", SQLTemplateArgument::TrustedSQL(StringUtil::Join(
                                   tokenize_fields, " UNION ALL "))},
        {"analyzed_tokens",
-        SQLTemplateArgument::TrustedSQL(
-            RenderAnalyzeTokenStream(qname, stemmer, "", filter_stopwords))}});
+        SQLTemplateArgument::TrustedSQL(RenderAnalyzeTokenStream(
+            qname, analyzer_config, AnalyzeTokenStreamProjection::NONE))}});
   auto trigger_names = GetFTSDeleteTriggerNames(qname);
   return RenderSQLTemplate(
       fts_sql::DELETE_TRIGGERS,
@@ -433,25 +427,24 @@ static string ClusteredDeleteTriggerScript(const QualifiedName &qname,
 string FTSIndexMaintenance::Create(const QualifiedName &qname,
                                    const string &input_id,
                                    const vector<string> &input_values,
-                                   const string &stemmer, bool filter_stopwords,
-                                   bool cluster_terms, bool layered_search) {
+                                   const FTSIndexMaintenanceConfig &config) {
   string result = IncrementalIndexSetupScript(qname);
-  if (layered_search) {
-    result += InsertTriggerScript(qname, input_id, input_values, stemmer,
-                                  filter_stopwords, true);
-    result += DeleteTriggerScript(qname, input_id, input_values, stemmer,
-                                  filter_stopwords, true);
-  } else if (cluster_terms) {
+  if (config.layered_search) {
+    result += InsertTriggerScript(qname, input_id, input_values,
+                                  config.analyzer, true);
+    result += DeleteTriggerScript(qname, input_id, input_values,
+                                  config.analyzer, true);
+  } else if (config.cluster_terms) {
     result += ClusteredIncrementalIndexSetupScript(qname);
     result += ClusteredInsertTriggerScript(qname, input_id, input_values,
-                                           stemmer, filter_stopwords);
+                                           config.analyzer);
     result +=
         ClusteredDeleteTriggerScript(qname, input_id, input_values.size());
   } else {
-    result += InsertTriggerScript(qname, input_id, input_values, stemmer,
-                                  filter_stopwords, false);
-    result += DeleteTriggerScript(qname, input_id, input_values, stemmer,
-                                  filter_stopwords, false);
+    result += InsertTriggerScript(qname, input_id, input_values,
+                                  config.analyzer, false);
+    result += DeleteTriggerScript(qname, input_id, input_values,
+                                  config.analyzer, false);
   }
   return result;
 }

--- a/src/fts_index_maintenance.cpp
+++ b/src/fts_index_maintenance.cpp
@@ -194,7 +194,8 @@ static vector<string> BuildInsertedFieldQueries(
 static string InsertTriggerScript(const QualifiedName &qname,
                                   const string &input_id,
                                   const vector<string> &input_values,
-                                  const string &stemmer, bool layered_search) {
+                                  const string &stemmer, bool filter_stopwords,
+                                  bool layered_search) {
   vector<string> input_value_selects;
   auto tokenize_fields = BuildInsertedFieldQueries(
       qname, input_values, input_value_selects, layered_search);
@@ -218,11 +219,14 @@ static string InsertTriggerScript(const QualifiedName &qname,
       {{"new_docs_cte", SQLTemplateArgument::TrustedSQL(token_new_docs_cte)},
        {"union_fields_query",
         SQLTemplateArgument::TrustedSQL(union_fields_query)},
-       {"stemmer", SQLTemplateArgument::StringLiteral(stemmer)},
-       {"position_select",
-        SQLTemplateArgument::TrustedSQL(
-            layered_search ? ",\n           t.position AS position" : "")},
-       {"fts_schema", GetFTSSchemaArgument(qname)}});
+       {"analyzed_tokens",
+        SQLTemplateArgument::TrustedSQL(RenderAnalyzeTokenStream(
+            qname, stemmer,
+            layered_search ? ",\n       tokenized.docid,\n       "
+                             "tokenized.fieldid,\n       tokenized.position"
+                           : ",\n       tokenized.docid,\n       "
+                             "tokenized.fieldid",
+            filter_stopwords))}});
   auto trigger_names = GetFTSInsertTriggerNames(qname);
   auto raw_dict_join =
       layered_search ? "JOIN " + GetFTSSchema(qname) +
@@ -244,7 +248,11 @@ static string InsertTriggerScript(const QualifiedName &qname,
         SQLTemplateArgument::TrustedSQL(docs_new_docs_cte)},
        {"union_fields_query",
         SQLTemplateArgument::TrustedSQL(union_fields_query)},
-       {"stemmer", SQLTemplateArgument::StringLiteral(stemmer)},
+       {"analyzed_tokens",
+        SQLTemplateArgument::TrustedSQL(RenderAnalyzeTokenStream(
+            qname, stemmer,
+            ",\n       tokenized.docid,\n       tokenized.fieldid",
+            filter_stopwords))},
        {"field_length_aggregates",
         SQLTemplateArgument::TrustedSQL(
             FieldLengthAggregateList(input_values.size()))},
@@ -284,7 +292,8 @@ static string InsertTriggerScript(const QualifiedName &qname,
 static string ClusteredInsertTriggerScript(const QualifiedName &qname,
                                            const string &input_id,
                                            const vector<string> &input_values,
-                                           const string &stemmer) {
+                                           const string &stemmer,
+                                           bool filter_stopwords) {
   vector<string> input_value_selects;
   auto tokenize_fields = BuildInsertedFieldQueries(qname, input_values,
                                                    input_value_selects, false);
@@ -308,8 +317,11 @@ static string ClusteredInsertTriggerScript(const QualifiedName &qname,
       {{"new_docs_cte", SQLTemplateArgument::TrustedSQL(token_new_docs_cte)},
        {"union_fields_query",
         SQLTemplateArgument::TrustedSQL(union_fields_query)},
-       {"stemmer", SQLTemplateArgument::StringLiteral(stemmer)},
-       {"fts_schema", GetFTSSchemaArgument(qname)}});
+       {"analyzed_tokens",
+        SQLTemplateArgument::TrustedSQL(RenderAnalyzeTokenStream(
+            qname, stemmer,
+            ",\n       tokenized.docid,\n       tokenized.fieldid",
+            filter_stopwords))}});
   auto trigger_names = GetFTSClusteredInsertTriggerNames(qname);
   return RenderSQLTemplate(
       fts_sql::CLUSTERED_INSERT_TRIGGERS,
@@ -327,7 +339,11 @@ static string ClusteredInsertTriggerScript(const QualifiedName &qname,
         SQLTemplateArgument::TrustedSQL(docs_new_docs_cte)},
        {"union_fields_query",
         SQLTemplateArgument::TrustedSQL(union_fields_query)},
-       {"stemmer", SQLTemplateArgument::StringLiteral(stemmer)},
+       {"analyzed_tokens",
+        SQLTemplateArgument::TrustedSQL(RenderAnalyzeTokenStream(
+            qname, stemmer,
+            ",\n       tokenized.docid,\n       tokenized.fieldid",
+            filter_stopwords))},
        {"field_length_aggregates",
         SQLTemplateArgument::TrustedSQL(
             FieldLengthAggregateList(input_values.size()))},
@@ -346,7 +362,8 @@ static string ClusteredInsertTriggerScript(const QualifiedName &qname,
 static string DeleteTriggerScript(const QualifiedName &qname,
                                   const string &input_id,
                                   const vector<string> &input_values,
-                                  const string &stemmer, bool layered_search) {
+                                  const string &stemmer, bool filter_stopwords,
+                                  bool layered_search) {
   vector<string> tokenize_fields;
   for (auto &input_value : input_values) {
     tokenize_fields.push_back(RenderSQLTemplate(
@@ -358,8 +375,9 @@ static string DeleteTriggerScript(const QualifiedName &qname,
       fts_sql::DELETE_TOKEN_CTES,
       {{"union_fields_query", SQLTemplateArgument::TrustedSQL(StringUtil::Join(
                                   tokenize_fields, " UNION ALL "))},
-       {"stemmer", SQLTemplateArgument::StringLiteral(stemmer)},
-       {"fts_schema", GetFTSSchemaArgument(qname)}});
+       {"analyzed_tokens",
+        SQLTemplateArgument::TrustedSQL(
+            RenderAnalyzeTokenStream(qname, stemmer, "", filter_stopwords))}});
   auto trigger_names = GetFTSDeleteTriggerNames(qname);
   return RenderSQLTemplate(
       fts_sql::DELETE_TRIGGERS,
@@ -415,23 +433,25 @@ static string ClusteredDeleteTriggerScript(const QualifiedName &qname,
 string FTSIndexMaintenance::Create(const QualifiedName &qname,
                                    const string &input_id,
                                    const vector<string> &input_values,
-                                   const string &stemmer, bool cluster_terms,
-                                   bool layered_search) {
+                                   const string &stemmer, bool filter_stopwords,
+                                   bool cluster_terms, bool layered_search) {
   string result = IncrementalIndexSetupScript(qname);
   if (layered_search) {
-    result += InsertTriggerScript(qname, input_id, input_values, stemmer, true);
-    result += DeleteTriggerScript(qname, input_id, input_values, stemmer, true);
+    result += InsertTriggerScript(qname, input_id, input_values, stemmer,
+                                  filter_stopwords, true);
+    result += DeleteTriggerScript(qname, input_id, input_values, stemmer,
+                                  filter_stopwords, true);
   } else if (cluster_terms) {
     result += ClusteredIncrementalIndexSetupScript(qname);
-    result +=
-        ClusteredInsertTriggerScript(qname, input_id, input_values, stemmer);
+    result += ClusteredInsertTriggerScript(qname, input_id, input_values,
+                                           stemmer, filter_stopwords);
     result +=
         ClusteredDeleteTriggerScript(qname, input_id, input_values.size());
   } else {
-    result +=
-        InsertTriggerScript(qname, input_id, input_values, stemmer, false);
-    result +=
-        DeleteTriggerScript(qname, input_id, input_values, stemmer, false);
+    result += InsertTriggerScript(qname, input_id, input_values, stemmer,
+                                  filter_stopwords, false);
+    result += DeleteTriggerScript(qname, input_id, input_values, stemmer,
+                                  filter_stopwords, false);
   }
   return result;
 }

--- a/src/include/fts_index_common.hpp
+++ b/src/include/fts_index_common.hpp
@@ -6,15 +6,27 @@
 
 namespace duckdb {
 
+struct FTSAnalyzerConfig {
+  string stemmer = "none";
+  bool filter_stopwords = false;
+};
+
+enum class AnalyzeTokenStreamProjection : uint8_t {
+  NONE,
+  POSITION,
+  DOCID_FIELDID,
+  DOCID_FIELDID_POSITION,
+  TOKEN_POSITION
+};
+
 string GetFTSSchemaName(const QualifiedName &qname);
 string GetFTSSchema(const QualifiedName &qname);
 SQLTemplateArgument GetFTSSchemaArgument(const QualifiedName &qname);
 string GetQualifiedTableName(const QualifiedName &qname);
 SQLTemplateArgument GetQualifiedTableArgument(const QualifiedName &qname);
 string RenderAnalyzeTokenStream(const QualifiedName &qname,
-                                const string &stemmer,
-                                const string &passthrough,
-                                bool filter_stopwords);
+                                const FTSAnalyzerConfig &config,
+                                AnalyzeTokenStreamProjection projection);
 
 vector<string> GetFTSInsertTriggerNames(const QualifiedName &qname);
 vector<string> GetFTSClusteredInsertTriggerNames(const QualifiedName &qname);

--- a/src/include/fts_index_common.hpp
+++ b/src/include/fts_index_common.hpp
@@ -11,6 +11,10 @@ string GetFTSSchema(const QualifiedName &qname);
 SQLTemplateArgument GetFTSSchemaArgument(const QualifiedName &qname);
 string GetQualifiedTableName(const QualifiedName &qname);
 SQLTemplateArgument GetQualifiedTableArgument(const QualifiedName &qname);
+string RenderAnalyzeTokenStream(const QualifiedName &qname,
+                                const string &stemmer,
+                                const string &passthrough,
+                                bool filter_stopwords);
 
 vector<string> GetFTSInsertTriggerNames(const QualifiedName &qname);
 vector<string> GetFTSClusteredInsertTriggerNames(const QualifiedName &qname);

--- a/src/include/fts_index_maintenance.hpp
+++ b/src/include/fts_index_maintenance.hpp
@@ -1,17 +1,24 @@
 #pragma once
 
+#include "fts_index_common.hpp"
+
 #include "duckdb/common/common.hpp"
 #include "duckdb/parser/qualified_name.hpp"
 
 namespace duckdb {
+
+struct FTSIndexMaintenanceConfig {
+  FTSAnalyzerConfig analyzer;
+  bool cluster_terms = false;
+  bool layered_search = false;
+};
 
 class FTSIndexMaintenance {
 public:
   static string DropTriggers(const QualifiedName &qname);
   static string Create(const QualifiedName &qname, const string &input_id,
                        const vector<string> &input_values,
-                       const string &stemmer, bool filter_stopwords,
-                       bool cluster_terms, bool layered_search);
+                       const FTSIndexMaintenanceConfig &config);
 };
 
 } // namespace duckdb

--- a/src/include/fts_index_maintenance.hpp
+++ b/src/include/fts_index_maintenance.hpp
@@ -10,8 +10,8 @@ public:
   static string DropTriggers(const QualifiedName &qname);
   static string Create(const QualifiedName &qname, const string &input_id,
                        const vector<string> &input_values,
-                       const string &stemmer, bool cluster_terms,
-                       bool layered_search);
+                       const string &stemmer, bool filter_stopwords,
+                       bool cluster_terms, bool layered_search);
 };
 
 } // namespace duckdb

--- a/src/sql/index/analyze_text_macro.sql
+++ b/src/sql/index/analyze_text_macro.sql
@@ -1,0 +1,38 @@
+CREATE MACRO {{fts_schema}}.analyze_text(s) AS TABLE
+WITH positioned_tokens AS (
+    SELECT token.raw_term,
+           token.position::UINTEGER AS position
+    FROM UNNEST(
+        list_filter(
+            {{fts_schema}}.tokenize(s),
+            lambda value: value IS NOT NULL AND value <> ''
+        )
+    ) WITH ORDINALITY AS token(raw_term, position)
+),
+tokenized AS (
+    SELECT raw_term,
+           position
+    FROM positioned_tokens
+),
+analyzed_tokens AS (
+    {{analyzed_tokens}}
+),
+token_stream AS (
+    SELECT raw_term,
+           term,
+           position,
+           (
+               position
+               - coalesce(lag(position) OVER (ORDER BY position), 0)
+           )::UINTEGER AS position_increment
+    FROM analyzed_tokens
+)
+SELECT raw_term,
+       term,
+       position,
+       position_increment,
+       1::UINTEGER AS position_length,
+       NULL::UINTEGER AS start_offset,
+       NULL::UINTEGER AS end_offset,
+       'word'::VARCHAR AS token_type
+FROM token_stream;

--- a/src/sql/index/analyze_token_stream.sql
+++ b/src/sql/index/analyze_token_stream.sql
@@ -1,0 +1,7 @@
+SELECT tokenized.raw_term,
+       {{term_expression}} AS term
+       {{passthrough}}
+FROM tokenized
+WHERE tokenized.raw_term IS NOT NULL
+  AND tokenized.raw_term <> ''
+{{stopwords_filter}}

--- a/src/sql/index/analyze_token_stream.sql
+++ b/src/sql/index/analyze_token_stream.sql
@@ -1,7 +1,12 @@
-SELECT tokenized.raw_term,
-       {{term_expression}} AS term
-       {{passthrough}}
-FROM tokenized
-WHERE tokenized.raw_term IS NOT NULL
-  AND tokenized.raw_term <> ''
-{{stopwords_filter}}
+SELECT analyzed.*
+FROM (
+    SELECT tokenized.raw_term,
+           {{term_expression}} AS term
+           {{projected_columns}}
+    FROM tokenized
+    WHERE tokenized.raw_term IS NOT NULL
+      AND tokenized.raw_term <> ''
+    {{stopwords_filter}}
+) AS analyzed
+WHERE analyzed.term IS NOT NULL
+  AND analyzed.term <> ''

--- a/src/sql/index/analyze_token_stream.sql
+++ b/src/sql/index/analyze_token_stream.sql
@@ -1,12 +1,12 @@
-SELECT analyzed.*
-FROM (
-    SELECT tokenized.raw_term,
-           {{term_expression}} AS term
-           {{projected_columns}}
-    FROM tokenized
-    WHERE tokenized.raw_term IS NOT NULL
-      AND tokenized.raw_term <> ''
-    {{stopwords_filter}}
-) AS analyzed
-WHERE analyzed.term IS NOT NULL
-  AND analyzed.term <> ''
+SELECT tokenized.raw_term,
+       UNNEST(
+           list_filter(
+               [{{term_expression}}],
+               lambda term: term IS NOT NULL AND term <> ''
+           )
+       ) AS term
+       {{projected_columns}}
+FROM tokenized
+WHERE tokenized.raw_term IS NOT NULL
+  AND tokenized.raw_term <> ''
+{{stopwords_filter}}

--- a/src/sql/index/index_metadata.sql
+++ b/src/sql/index/index_metadata.sql
@@ -28,6 +28,7 @@ analyzer_metadata AS (
     FROM stopword_config
 )
 SELECT {{format_version}}::UINTEGER AS format_version,
+       {{analyzer_version}}::UINTEGER AS analyzer_version,
        {{incremental}}::BOOLEAN AS incremental,
        {{cluster_terms}}::BOOLEAN AS cluster_terms,
        {{layered_search}}::BOOLEAN AS layered_search,

--- a/src/sql/index/index_tables.sql
+++ b/src/sql/index/index_tables.sql
@@ -10,22 +10,14 @@ WITH tokenized AS (
     {{union_fields_query}}
 ),
 stemmed_stopped AS (
-    SELECT {{term_expression}} AS term,
-           {{raw_term_select}}
-           t.docid AS docid,
-           t.fieldid AS fieldid
-           {{build_position_select}}
-    FROM tokenized AS t
-    WHERE t.w NOT NULL
-      AND t.w <> ''
-      {{stopwords_filter}}
+    {{analyzed_tokens}}
 )
-SELECT ss.term,
+SELECT stemmed_stopped.term,
        {{raw_term_output}}
-       ss.docid,
-       ss.fieldid
+       stemmed_stopped.docid,
+       stemmed_stopped.fieldid
        {{build_position_output}}
-FROM stemmed_stopped AS ss;
+FROM stemmed_stopped;
 
 CREATE TABLE {{fts_schema}}.docs AS
 WITH lengths AS (

--- a/src/sql/index/tokenize_field.sql
+++ b/src/sql/index/tokenize_field.sql
@@ -1,4 +1,4 @@
-SELECT unnest({{fts_schema}}.tokenize(fts_ii.{{input_value}})) AS w,
+SELECT unnest({{fts_schema}}.tokenize(fts_ii.{{input_value}})) AS raw_term,
        fts_ii.rowid AS docid,
        {{field_id}} AS fieldid
 FROM {{input_table}} AS fts_ii

--- a/src/sql/index/tokenize_positional_field.sql
+++ b/src/sql/index/tokenize_positional_field.sql
@@ -1,4 +1,4 @@
-SELECT token.w,
+SELECT token.raw_term,
        fts_ii.rowid AS docid,
        {{field_id}} AS fieldid,
        token.position::UINTEGER AS position
@@ -8,4 +8,4 @@ CROSS JOIN LATERAL UNNEST(
         {{fts_schema}}.tokenize(fts_ii.{{input_value}}),
         lambda value: value IS NOT NULL AND value <> ''
     )
-) WITH ORDINALITY AS token(w, position)
+) WITH ORDINALITY AS token(raw_term, position)

--- a/src/sql/maintenance/clustered_insert_token_ctes.sql
+++ b/src/sql/maintenance/clustered_insert_token_ctes.sql
@@ -3,11 +3,5 @@ tokenized AS (
     {{union_fields_query}}
 ),
 stemmed_stopped AS (
-    SELECT stem(t.w, {{stemmer}}) AS term,
-           t.docid AS docid,
-           t.fieldid AS fieldid
-    FROM tokenized AS t
-    WHERE t.w NOT NULL
-      AND t.w <> ''
-      AND t.w NOT IN (SELECT sw FROM {{fts_schema}}.stopwords)
+    {{analyzed_tokens}}
 )

--- a/src/sql/maintenance/clustered_insert_triggers.sql
+++ b/src/sql/maintenance/clustered_insert_triggers.sql
@@ -7,13 +7,7 @@ FOR EACH STATEMENT
         {{union_fields_query}}
     ),
     stemmed_stopped AS (
-        SELECT stem(t.w, {{stemmer}}) AS term,
-               t.docid AS docid,
-               t.fieldid AS fieldid
-        FROM tokenized AS t
-        WHERE t.w NOT NULL
-          AND t.w <> ''
-          AND t.w NOT IN (SELECT sw FROM {{fts_schema}}.stopwords)
+        {{analyzed_tokens}}
     ),
     lengths AS (
         SELECT docid,

--- a/src/sql/maintenance/delete_token_ctes.sql
+++ b/src/sql/maintenance/delete_token_ctes.sql
@@ -2,10 +2,5 @@ WITH tokenized AS (
     {{union_fields_query}}
 ),
 stemmed_stopped AS (
-    SELECT t.w AS raw_term,
-           stem(t.w, {{stemmer}}) AS term
-    FROM tokenized AS t
-    WHERE t.w NOT NULL
-      AND t.w <> ''
-      AND t.w NOT IN (SELECT sw FROM {{fts_schema}}.stopwords)
+    {{analyzed_tokens}}
 )

--- a/src/sql/maintenance/insert_triggers.sql
+++ b/src/sql/maintenance/insert_triggers.sql
@@ -7,13 +7,7 @@ FOR EACH STATEMENT
         {{union_fields_query}}
     ),
     stemmed_stopped AS (
-        SELECT stem(t.w, {{stemmer}}) AS term,
-               t.docid AS docid,
-               t.fieldid AS fieldid
-        FROM tokenized AS t
-        WHERE t.w NOT NULL
-          AND t.w <> ''
-          AND t.w NOT IN (SELECT sw FROM {{fts_schema}}.stopwords)
+        {{analyzed_tokens}}
     ),
     lengths AS (
         SELECT docid,

--- a/src/sql/maintenance/layered_insert_token_ctes.sql
+++ b/src/sql/maintenance/layered_insert_token_ctes.sql
@@ -3,13 +3,5 @@ tokenized AS (
     {{union_fields_query}}
 ),
 stemmed_stopped AS (
-    SELECT t.w AS raw_term,
-           stem(t.w, {{stemmer}}) AS term,
-           t.docid AS docid,
-           t.fieldid AS fieldid
-           {{position_select}}
-    FROM tokenized AS t
-    WHERE t.w NOT NULL
-      AND t.w <> ''
-      AND t.w NOT IN (SELECT sw FROM {{fts_schema}}.stopwords)
+    {{analyzed_tokens}}
 )

--- a/src/sql/maintenance/tokenize_deleted_field.sql
+++ b/src/sql/maintenance/tokenize_deleted_field.sql
@@ -1,2 +1,2 @@
-SELECT unnest({{fts_schema}}.tokenize(fts_di.{{input_value}})) AS w
+SELECT unnest({{fts_schema}}.tokenize(fts_di.{{input_value}})) AS raw_term
 FROM fts_old_rows AS fts_di

--- a/src/sql/maintenance/tokenize_inserted_field.sql
+++ b/src/sql/maintenance/tokenize_inserted_field.sql
@@ -1,4 +1,4 @@
-SELECT unnest({{fts_schema}}.tokenize(fts_ii.{{input_value}})) AS w,
+SELECT unnest({{fts_schema}}.tokenize(fts_ii.{{input_value}})) AS raw_term,
        fts_ii.docid AS docid,
        (SELECT fieldid FROM {{fts_schema}}.fields WHERE field = {{input_value_string}}) AS fieldid
 FROM fts_new_docs AS fts_ii

--- a/src/sql/maintenance/tokenize_inserted_positional_field.sql
+++ b/src/sql/maintenance/tokenize_inserted_positional_field.sql
@@ -1,4 +1,4 @@
-SELECT unnest(tokens) AS w,
+SELECT unnest(tokens) AS raw_term,
        fts_ii.docid AS docid,
        (SELECT fieldid
         FROM {{fts_schema}}.fields

--- a/src/sql/query/match_bm25.sql
+++ b/src/sql/query/match_bm25.sql
@@ -7,23 +7,15 @@ CREATE MACRO {{fts_schema}}.match_bm25(docname, query_string, fields := NULL, k 
                b::DOUBLE AS default_b
     ),
     {{field_scoring_config_ctes}}
-    raw_tokens AS (
-        SELECT DISTINCT raw_token
-        FROM (
-            SELECT unnest({{fts_schema}}.tokenize(query_string)) AS raw_token
-        ) AS tokenized_query
-        WHERE raw_token IS NOT NULL
-          AND raw_token <> ''
-          AND raw_token NOT IN (SELECT sw FROM {{fts_schema}}.stopwords)
+    tokenized AS (
+        SELECT unnest({{fts_schema}}.tokenize(query_string)) AS raw_term
+    ),
+    analyzed_query_tokens AS (
+        {{analyzed_tokens}}
     ),
     tokens AS (
-        SELECT t
-        FROM (
-            SELECT DISTINCT stem(raw_token, {{stemmer}}) AS t
-            FROM raw_tokens
-        ) AS stemmed_tokens
-        WHERE t IS NOT NULL
-          AND t <> ''
+        SELECT DISTINCT term AS t
+        FROM analyzed_query_tokens
     ),
     qtermids AS (
         SELECT termid

--- a/src/sql/query/search_layered_bm25.sql
+++ b/src/sql/query/search_layered_bm25.sql
@@ -48,10 +48,9 @@ df_cap(max_df) AS (
     FROM {{fts_schema}}.stats AS stats
     CROSS JOIN params
 ),
-positioned_query_tokens AS (
-    SELECT unnest(tokens) AS raw_token,
-           generate_subscripts(tokens, 1)::BIGINT AS token_position,
-           generate_subscripts(tokens, 1) = len(tokens) AS is_final_token
+tokenized AS (
+    SELECT unnest(tokens) AS raw_term,
+           generate_subscripts(tokens, 1)::BIGINT AS token_position{{is_final_token}}
     FROM (
         SELECT list_filter(
                    {{fts_schema}}.tokenize(query_string),
@@ -59,28 +58,28 @@ positioned_query_tokens AS (
                ) AS tokens
     ) AS query_token_list
 ),
-analyzed_query_tokens AS (
-    SELECT raw_token,
-           token_position
-    FROM positioned_query_tokens
-    CROSS JOIN params
-    WHERE raw_token NOT IN (SELECT sw FROM {{fts_schema}}.stopwords)
-       OR (
-           params.query_mode = 'phrase_prefix'
-           AND is_final_token
-       )
+query_analyzer_tokens AS (
+    SELECT analyzed.raw_term AS raw_token,
+           analyzed.term,
+           analyzed.token_position
+    FROM (
+        {{analyzed_tokens}}
+    ) AS analyzed
+    {{phrase_prefix_stopword_token}}
 ),
 query_shape AS (
     SELECT count(*)::BIGINT AS token_count,
            max(token_position) AS final_position,
            CASE
-               WHEN params.query_mode = 'phrase' AND count(*) = 1
+               WHEN params.query_mode = 'phrase'
+                AND count(*) = 1
                    THEN 'standard'
-               WHEN params.query_mode = 'phrase_prefix' AND count(*) = 1
+               WHEN params.query_mode = 'phrase_prefix'
+                AND count(*) = 1
                    THEN 'autocomplete'
                ELSE params.query_mode
            END AS effective_mode
-    FROM analyzed_query_tokens
+    FROM query_analyzer_tokens
     CROSS JOIN params
     GROUP BY params.query_mode
 ),
@@ -89,7 +88,7 @@ autocomplete_final_token AS (
            length(raw_token)::BIGINT AS query_len,
            least(length(raw_token), 3)::UTINYINT AS prefix_len,
            substr(raw_token, 1, least(length(raw_token), 3)) AS prefix
-    FROM analyzed_query_tokens
+    FROM query_analyzer_tokens
     CROSS JOIN query_shape
     WHERE query_shape.effective_mode = 'autocomplete'
       AND token_position = query_shape.final_position
@@ -98,8 +97,8 @@ autocomplete_final_token AS (
 stemmed_tokens AS (
     SELECT DISTINCT query_term
     FROM (
-        SELECT stem(raw_token, {{stemmer}}) AS query_term
-        FROM analyzed_query_tokens
+        SELECT term AS query_term
+        FROM query_analyzer_tokens
         CROSS JOIN query_shape
         WHERE query_shape.effective_mode = 'standard'
            OR (
@@ -360,11 +359,11 @@ autocomplete_prefix_terms AS (
 ),
 phrase_tokens AS (
     SELECT raw_token,
-           stem(raw_token, {{stemmer}}) AS term,
+           term,
            token_position,
            token_position - 1 AS relative_position,
            token_position AS phrase_slot
-    FROM analyzed_query_tokens
+    FROM query_analyzer_tokens
     CROSS JOIN query_shape
     WHERE query_shape.effective_mode IN ('phrase', 'phrase_prefix')
 ),

--- a/test/sql/fts/test_analyzer_contract.test
+++ b/test/sql/fts/test_analyzer_contract.test
@@ -116,7 +116,10 @@ statement ok
 CREATE TABLE empty_stem_docs(id VARCHAR, body VARCHAR)
 
 statement ok
-INSERT INTO empty_stem_docs VALUES ('john', 'John''s guide'), ('other', 'other')
+INSERT INTO empty_stem_docs VALUES
+    ('john', 'John''s guide'),
+    ('other', 'other'),
+    ('empty', 's')
 
 statement ok
 PRAGMA create_fts_index(
@@ -169,6 +172,19 @@ SELECT count(*) FILTER (
            )
        ) AS layered_matches
 FROM empty_stem_docs
+----
+0	0
+
+query II
+SELECT (
+           SELECT count(*)
+           FROM fts_main_empty_stem_docs.analyze_text('s')
+       ) AS analyzed_terms,
+       (
+           SELECT len
+           FROM fts_main_empty_stem_docs.docs
+           WHERE name = 'empty'
+       ) AS indexed_terms
 ----
 0	0
 

--- a/test/sql/fts/test_analyzer_contract.test
+++ b/test/sql/fts/test_analyzer_contract.test
@@ -1,0 +1,349 @@
+# name: test/sql/fts/test_analyzer_contract.test
+# description: Canonical index-scoped analyzer token stream
+# group: [fts]
+
+require skip_reload
+
+require fts
+
+require no_alternative_verify
+
+statement ok
+CREATE TABLE analyzer_docs(
+    id INTEGER NOT NULL,
+    title VARCHAR,
+    body VARCHAR
+)
+
+statement ok
+INSERT INTO analyzer_docs VALUES
+    (1, 'The RUNNING,,, café foxes', 'alpha the beta'),
+    (2, 'A runner', NULL),
+    (3, '', '')
+
+statement ok
+PRAGMA create_fts_index(
+    'analyzer_docs',
+    'id',
+    'title',
+    'body',
+    stemmer='porter',
+    stopwords='english',
+    ignore='[,]+',
+    strip_accents=true,
+    lower=true,
+    layered_search=true
+)
+
+# The public stream contains normalized raw terms and final indexed terms.
+# Empty tokenizer output is removed before positions are assigned, while
+# stopwords retain gaps in the absolute position and position increment.
+query ITTTIIIIIT
+SELECT id,
+       source_field,
+       raw_term,
+       term,
+       position,
+       position_increment,
+       position_length,
+       start_offset,
+       end_offset,
+       token_type
+FROM (
+    SELECT docs.id,
+           'title' AS source_field,
+           analyzed.*
+    FROM analyzer_docs AS docs
+    CROSS JOIN LATERAL fts_main_analyzer_docs.analyze_text(docs.title) AS analyzed
+    UNION ALL
+    SELECT docs.id,
+           'body' AS source_field,
+           analyzed.*
+    FROM analyzer_docs AS docs
+    CROSS JOIN LATERAL fts_main_analyzer_docs.analyze_text(docs.body) AS analyzed
+) AS streams
+ORDER BY id,
+         source_field DESC,
+         position
+----
+1	title	running	run	2	2	1	NULL	NULL	word
+1	title	cafe	cafe	3	1	1	NULL	NULL	word
+1	title	foxes	fox	4	1	1	NULL	NULL	word
+1	body	alpha	alpha	1	1	1	NULL	NULL	word
+1	body	beta	beta	3	2	1	NULL	NULL	word
+2	title	runner	runner	2	2	1	NULL	NULL	word
+
+# Every invocation has an independent position-increment window.
+query IIII
+SELECT docs.id,
+       analyzed.position,
+       analyzed.position_increment,
+       analyzed.position_length
+FROM analyzer_docs AS docs
+CROSS JOIN LATERAL fts_main_analyzer_docs.analyze_text(docs.title) AS analyzed
+WHERE analyzed.position = (
+    SELECT min(first_token.position)
+    FROM fts_main_analyzer_docs.analyze_text(docs.title) AS first_token
+)
+ORDER BY docs.id
+----
+1	2	2	1
+2	2	2	1
+
+query TTTTTTTT
+SELECT typeof(raw_term),
+       typeof(term),
+       typeof(position),
+       typeof(position_increment),
+       typeof(position_length),
+       typeof(start_offset),
+       typeof(end_offset),
+       typeof(token_type)
+FROM fts_main_analyzer_docs.analyze_text('alpha')
+----
+VARCHAR	VARCHAR	UINTEGER	UINTEGER	UINTEGER	UINTEGER	UINTEGER	VARCHAR
+
+query II
+SELECT (SELECT count(*) FROM fts_main_analyzer_docs.analyze_text(NULL::VARCHAR)),
+       (SELECT count(*) FROM fts_main_analyzer_docs.analyze_text(''))
+----
+0	0
+
+# The canonical stream and physical positional postings contain the same
+# occurrence rows for every indexed field.
+query I
+WITH inspected AS (
+    SELECT docs.id,
+           fields.fieldid,
+           analyzed.raw_term,
+           analyzed.term,
+           analyzed.position
+    FROM analyzer_docs AS docs
+    JOIN fts_main_analyzer_docs.fields AS fields ON fields.field = 'title'
+    CROSS JOIN LATERAL fts_main_analyzer_docs.analyze_text(docs.title) AS analyzed
+    UNION ALL
+    SELECT docs.id,
+           fields.fieldid,
+           analyzed.raw_term,
+           analyzed.term,
+           analyzed.position
+    FROM analyzer_docs AS docs
+    JOIN fts_main_analyzer_docs.fields AS fields ON fields.field = 'body'
+    CROSS JOIN LATERAL fts_main_analyzer_docs.analyze_text(docs.body) AS analyzed
+),
+stored AS (
+    SELECT docs.name AS id,
+           terms.fieldid,
+           raw_dict.raw_term,
+           dict.term,
+           terms.position
+    FROM fts_main_analyzer_docs.terms AS terms
+    JOIN fts_main_analyzer_docs.docs AS docs USING (docid)
+    JOIN fts_main_analyzer_docs.dict AS dict USING (termid)
+    JOIN fts_main_analyzer_docs.raw_dict AS raw_dict USING (rawtermid)
+)
+SELECT count(*)
+FROM (
+    (FROM inspected EXCEPT ALL FROM stored)
+    UNION ALL
+    (FROM stored EXCEPT ALL FROM inspected)
+)
+----
+0
+
+# Metadata versions the index layout and token-stream contract independently.
+query IIII
+SELECT format_version,
+       analyzer_version,
+       analyzer_config LIKE 'version:1:1;%',
+       analyzer_fingerprint = md5(analyzer_config)
+FROM fts_main_analyzer_docs.index_metadata
+----
+3	1	true	true
+
+# The OpenSearch-compatible tokenizer feeds the same analyzer contract.
+statement ok
+CREATE TABLE opensearch_analyzer_docs(id INTEGER, body VARCHAR)
+
+statement ok
+INSERT INTO opensearch_analyzer_docs VALUES
+    (1, 'Привет-мир مرحبا 🙂test')
+
+statement ok
+PRAGMA create_fts_index(
+    'opensearch_analyzer_docs',
+    'id',
+    'body',
+    tokenizer='opensearch_standard',
+    stemmer='none',
+    stopwords='none',
+    layered_search=true
+)
+
+query TTIII
+SELECT raw_term,
+       term,
+       position,
+       position_increment,
+       position_length
+FROM fts_main_opensearch_analyzer_docs.analyze_text(
+    'Привет-мир مرحبا 🙂test'
+)
+ORDER BY position
+----
+привет	привет	1	1	1
+мир	мир	2	1	1
+مرحبا	مرحبا	3	1	1
+🙂	🙂	4	1	1
+test	test	5	1	1
+
+# Incremental inserts produce the same postings as the bulk build.
+statement ok
+CREATE TABLE incremental_analyzer_docs(
+    id INTEGER NOT NULL,
+    title VARCHAR,
+    body VARCHAR
+)
+
+statement ok
+PRAGMA create_fts_index(
+    'incremental_analyzer_docs',
+    'id',
+    'title',
+    'body',
+    stemmer='porter',
+    stopwords='english',
+    ignore='[,]+',
+    strip_accents=true,
+    lower=true,
+    layered_search=true,
+    incremental=true
+)
+
+statement ok
+INSERT INTO incremental_analyzer_docs
+SELECT *
+FROM analyzer_docs
+
+query I
+WITH bulk AS (
+    SELECT docs.name,
+           dict.term,
+           raw_dict.raw_term,
+           terms.fieldid,
+           terms.position
+    FROM fts_main_analyzer_docs.terms AS terms
+    JOIN fts_main_analyzer_docs.docs AS docs USING (docid)
+    JOIN fts_main_analyzer_docs.dict AS dict USING (termid)
+    JOIN fts_main_analyzer_docs.raw_dict AS raw_dict USING (rawtermid)
+),
+incremental AS (
+    SELECT docs.name,
+           dict.term,
+           raw_dict.raw_term,
+           terms.fieldid,
+           terms.position
+    FROM fts_main_incremental_analyzer_docs.terms AS terms
+    JOIN fts_main_incremental_analyzer_docs.docs AS docs USING (docid)
+    JOIN fts_main_incremental_analyzer_docs.dict AS dict USING (termid)
+    JOIN fts_main_incremental_analyzer_docs.raw_dict AS raw_dict USING (rawtermid)
+)
+SELECT count(*)
+FROM (
+    (FROM bulk EXCEPT ALL FROM incremental)
+    UNION ALL
+    (FROM incremental EXCEPT ALL FROM bulk)
+)
+----
+0
+
+statement ok
+DELETE FROM incremental_analyzer_docs WHERE id = 1
+
+statement ok
+CREATE TABLE rebuilt_analyzer_docs AS
+SELECT *
+FROM incremental_analyzer_docs
+
+statement ok
+PRAGMA create_fts_index(
+    'rebuilt_analyzer_docs',
+    'id',
+    'title',
+    'body',
+    stemmer='porter',
+    stopwords='english',
+    ignore='[,]+',
+    strip_accents=true,
+    lower=true,
+    layered_search=true
+)
+
+query I
+WITH incremental AS (
+    SELECT docs.name,
+           dict.term,
+           raw_dict.raw_term,
+           terms.fieldid,
+           terms.position
+    FROM fts_main_incremental_analyzer_docs.terms AS terms
+    JOIN fts_main_incremental_analyzer_docs.docs AS docs USING (docid)
+    JOIN fts_main_incremental_analyzer_docs.dict AS dict USING (termid)
+    JOIN fts_main_incremental_analyzer_docs.raw_dict AS raw_dict USING (rawtermid)
+),
+rebuilt AS (
+    SELECT docs.name,
+           dict.term,
+           raw_dict.raw_term,
+           terms.fieldid,
+           terms.position
+    FROM fts_main_rebuilt_analyzer_docs.terms AS terms
+    JOIN fts_main_rebuilt_analyzer_docs.docs AS docs USING (docid)
+    JOIN fts_main_rebuilt_analyzer_docs.dict AS dict USING (termid)
+    JOIN fts_main_rebuilt_analyzer_docs.raw_dict AS raw_dict USING (rawtermid)
+)
+SELECT count(*)
+FROM (
+    (FROM incremental EXCEPT ALL FROM rebuilt)
+    UNION ALL
+    (FROM rebuilt EXCEPT ALL FROM incremental)
+)
+----
+0
+
+# Non-layered indexes expose the same inspection API without adding positions
+# to their physical terms table.
+statement ok
+CREATE TABLE plain_analyzer_docs(id INTEGER, body VARCHAR)
+
+statement ok
+INSERT INTO plain_analyzer_docs VALUES (1, 'the running foxes')
+
+statement ok
+PRAGMA create_fts_index(
+    'plain_analyzer_docs',
+    'id',
+    'body',
+    stemmer='porter',
+    stopwords='english'
+)
+
+query TTII
+SELECT raw_term,
+       term,
+       position,
+       position_increment
+FROM fts_main_plain_analyzer_docs.analyze_text('the running foxes')
+ORDER BY position
+----
+running	run	2	2
+foxes	fox	3	1
+
+query I
+SELECT count(*)
+FROM duckdb_columns()
+WHERE schema_name = 'fts_main_plain_analyzer_docs'
+  AND table_name = 'terms'
+  AND column_name = 'position'
+----
+0

--- a/test/sql/fts/test_analyzer_contract.test
+++ b/test/sql/fts/test_analyzer_contract.test
@@ -109,6 +109,69 @@ SELECT (SELECT count(*) FROM fts_main_analyzer_docs.analyze_text(NULL::VARCHAR))
 ----
 0	0
 
+# Stemmer output is part of the analyzer contract. Porter stems possessive
+# token "s" to an empty string, which must not enter the index or either query
+# path.
+statement ok
+CREATE TABLE empty_stem_docs(id VARCHAR, body VARCHAR)
+
+statement ok
+INSERT INTO empty_stem_docs VALUES ('john', 'John''s guide'), ('other', 'other')
+
+statement ok
+PRAGMA create_fts_index(
+    'empty_stem_docs',
+    'id',
+    'body',
+    stemmer='porter',
+    stopwords='none',
+    layered_search=true
+)
+
+query II
+SELECT (
+           SELECT count(*)
+           FROM fts_main_empty_stem_docs.analyze_text('Alice''s')
+           WHERE term = ''
+       ) AS empty_final_terms,
+       (
+           SELECT count(*)
+           FROM (
+               SELECT id AS docname
+               FROM empty_stem_docs
+               WHERE fts_main_empty_stem_docs.match_bm25(
+                   id,
+                   'Alice''s'
+               ) IS NOT NULL
+               EXCEPT
+               SELECT docname
+               FROM fts_main_empty_stem_docs.search_layered_bm25(
+                   'Alice''s',
+                   top_k := NULL
+               )
+           )
+       ) AS mismatched_results
+----
+0	0
+
+query II
+SELECT count(*) FILTER (
+           WHERE fts_main_empty_stem_docs.match_bm25(
+               id,
+               'Alice''s'
+           ) IS NOT NULL
+       ) AS base_matches,
+       (
+           SELECT count(*)
+           FROM fts_main_empty_stem_docs.search_layered_bm25(
+               'Alice''s',
+               top_k := NULL
+           )
+       ) AS layered_matches
+FROM empty_stem_docs
+----
+0	0
+
 # The canonical stream and physical positional postings contain the same
 # occurrence rows for every indexed field.
 query I

--- a/test/sql/fts/test_indexing.test_slow
+++ b/test/sql/fts/test_indexing.test_slow
@@ -63,7 +63,11 @@ two
 three
 
 query III
-SELECT termid, docid, fieldid FROM fts_main_documents.terms
+SELECT termid, docid, fieldid
+FROM fts_main_documents.terms
+ORDER BY docid,
+         termid,
+         fieldid
 ----
 0	0	0
 0	0	0
@@ -95,7 +99,9 @@ SELECT termid, term, df FROM fts_main_documents.dict
 query T
 WITH ppterms AS (SELECT stem(unnest(string_split_regex(regexp_replace(lower(strip_accents('QUÁCKED BÁRKED')), '[^a-z]', ' ', 'g'), '\s+')), 'porter') AS term),
 qtermids AS (SELECT termid FROM fts_main_documents.dict AS dict, ppterms WHERE dict.term = ppterms.term)
-SELECT * FROM qtermids
+SELECT *
+FROM qtermids
+ORDER BY termid
 ----
 0
 1
@@ -104,7 +110,10 @@ query II
 WITH ppterms AS (SELECT stem(unnest(string_split_regex(regexp_replace(lower(strip_accents('QUÁCKED BÁRKED')), '[^a-z]', ' ', 'g'), '\s+')), 'porter') AS term),
 qtermids AS (SELECT termid FROM fts_main_documents.dict AS dict, ppterms WHERE dict.term = ppterms.term),
 qterms AS (SELECT termid, docid FROM fts_main_documents.terms AS terms WHERE termid IN (SELECT qtermids.termid FROM qtermids))
-SELECT * FROM qterms
+SELECT *
+FROM qterms
+ORDER BY termid,
+         docid
 ----
 0	0
 0	0

--- a/test/sql/fts/test_phrase_search.test
+++ b/test/sql/fts/test_phrase_search.test
@@ -70,9 +70,10 @@ WHERE schema_name = 'fts_main_phrase_docs'
 ----
 UINTEGER
 
-# Index metadata describes the physical format and canonical analyzer.
-query IIIIIIII
+# Index metadata versions the positional layout and analyzer stream contract.
+query IIIIIIIII
 SELECT format_version,
+       analyzer_version,
        incremental,
        cluster_terms,
        layered_search,
@@ -82,7 +83,7 @@ SELECT format_version,
        analyzer_fingerprint = md5(analyzer_config)
 FROM fts_main_phrase_docs.index_metadata
 ----
-2	true	true	true	true	true	32	true
+3	1	true	true	true	true	true	32	true
 
 # Analyzer identity follows effective stopword contents, while source names are
 # retained separately as provenance.
@@ -274,6 +275,12 @@ EXECUTE phrase_docnames('vector the dat', NULL, 32, 0.15, 50000, true, true, tru
 ----
 p2
 p9
+
+# A trailing stopword remains the unfinished prefix and must not make the
+# preceding analyzed token fall back to one-token autocomplete.
+query I
+EXECUTE phrase_docnames('vector the', NULL, 32, 0.15, 50000, true, true, true, true, 1.2, 0.75, 'phrase_prefix')
+----
 
 # Standard expansion switches and document-frequency caps do not constrain the
 # dedicated final-token prefix path.


### PR DESCRIPTION
The positional index work made analyzer behavior part of the persisted index
contract, but the same behavior was still implemented separately in bulk
indexing, incremental maintenance, and query analysis. That made it easy for
token filtering, stemming, or position handling to diverge between paths.

I added an index-scoped `analyze_text(text)` table macro that exposes the final
token stream:

```sql
SELECT *
FROM fts_main_documents.analyze_text('The running foxes')
ORDER BY position;
```

The result contains the normalized `raw_term`, indexed `term`, absolute
one-based position, position increment, position length, nullable offsets, and
token type. Empty tokenizer output is removed before positions are assigned,
while stopword removal preserves position gaps. Offsets are deliberately
`NULL` for now because the existing normalization stages cannot reliably map
every token back to byte offsets in the original input.

Bulk indexing, incremental insert/delete maintenance, `match_bm25`, layered
query analysis, and the inspection macro now use the same generated analyzer
SQL. I initially routed these paths through an internal table macro, but the
correlated macro boundary materially regressed index construction and
incremental maintenance. The final implementation renders the shared analyzer
fragment directly into each set-oriented query. It also omits the stopword join
and stemming call when those stages are disabled.

Phrase-prefix needs one intentional exception to the final indexed stream: its
unfinished last token may itself be a stopword prefix, such as `be`. For
stopword-enabled analyzers I retain that final raw token for prefix expansion
without treating it as an indexed exact term. Analyzers without stopwords do
not generate this extra branch.

The index metadata now records analyzer contract version 1, and the physical
format version moves to 3. I am not adding a migration path for older indexes;
they must be dropped and rebuilt. The analyzer version is also part of the
canonical analyzer configuration and fingerprint.

The SQLLogicTest coverage checks regex and OpenSearch-compatible tokenizers,
Unicode input, empty and `NULL` input, stemming, stopword gaps, multiple lateral
invocations, bulk versus inspected postings, incremental insert/delete parity,
non-layered indexes, and the trailing-stopword phrase-prefix case.

I also added synthetic benchmark_runner coverage for analyzer inspection and
for base regex, layered regex, and layered OpenSearch index construction. The
analyzer benchmarks are current-only because the base runner does not expose
`analyze_text`; the existing layered, autocomplete, field-scoring, Boolean, and
phrase workloads remain base-versus-current regression gates.

One final local smoke comparison produced:

| benchmark | base | current | change |
|---|---:|---:|---:|
| layered suite geometric mean | 45.09 ms | 45.36 ms | +0.6% |
| autocomplete geometric mean | 27.63 ms | 28.36 ms | +2.6% |
| field-scoring geometric mean | 27.73 ms | 27.69 ms | -0.1% |
| Boolean geometric mean | 210.75 ms | 210.16 ms | -0.3% |
| phrase geometric mean | 35.47 ms | 35.56 ms | +0.3% |
| incremental insert | 37.34 ms | 37.21 ms | -0.3% |
| incremental delete | 9.48 ms | 9.23 ms | -2.6% |
| base regex index creation | 331.30 ms | 347.47 ms | +4.9% |
| layered regex index creation | 449.27 ms | 457.54 ms | +1.8% |
| layered OpenSearch index creation | 539.55 ms | 546.25 ms | +1.2% |
