### PR TITLE
Reject unknown names in the fields argument

### DIFF
--- a/src/fts_index_builder.cpp
+++ b/src/fts_index_builder.cpp
@@ -248,7 +248,20 @@ FieldScoringValidationCTEs(const QualifiedName &qname,
                            const string &field_b_name = "field_b",
                            const string &scoring_model_name = "scoring_model",
                            const string &tie_breaker_name = "tie_breaker",
-                           const string &default_b_name = "default_b") {
+                           const string &default_b_name = "default_b",
+                           bool validate_requested_fields = true) {
+  // Checked before the weighting maps because 'fields' selects what is searched
+  // at all. An empty 'fields' selects nothing and returns no rows, which
+  // test_indexing pins deliberately.
+  auto requested_fields_validation =
+      validate_requested_fields
+          ? "\n    UNION ALL\n"
+            "    SELECT 15 AS priority,\n"
+            "           'fields contains unknown field: ' || field AS message\n"
+            "    FROM requested_fields\n"
+            "    WHERE field NOT IN (SELECT field FROM " +
+                GetFTSSchema(qname) + ".fields)"
+          : "";
   return RenderSQLTemplate(
       fts_sql::FIELD_SCORING_VALIDATION_CTES,
       {{"fts_schema", GetFTSSchemaArgument(qname)},
@@ -257,7 +270,9 @@ FieldScoringValidationCTEs(const QualifiedName &qname,
        {"field_b", SQLTemplateArgument::Identifier(field_b_name)},
        {"scoring_model", SQLTemplateArgument::Identifier(scoring_model_name)},
        {"tie_breaker", SQLTemplateArgument::Identifier(tie_breaker_name)},
-       {"default_b", SQLTemplateArgument::Identifier(default_b_name)}});
+       {"default_b", SQLTemplateArgument::Identifier(default_b_name)},
+       {"requested_fields_validation",
+        SQLTemplateArgument::TrustedSQL(requested_fields_validation)}});
 }
 
 static string FieldScoringConfigCTEs(const QualifiedName &qname) {
@@ -352,7 +367,8 @@ StructuredLayeredSearchTableMacroScript(const QualifiedName &qname) {
        {"field_scoring_validation_ctes",
         SQLTemplateArgument::TrustedSQL(FieldScoringValidationCTEs(
             qname, "query_params", "scoring_weights", "scoring_field_b",
-            "scoring_model", "scoring_tie_breaker", "bm25_b"))}});
+            "scoring_model", "scoring_tie_breaker", "bm25_b",
+            /* validate_requested_fields */ false))}});
 }
 
 static string StructuredLayeredMatchMacroScript(const QualifiedName &qname) {

--- a/src/sql/query/field_scoring_validation_ctes.sql
+++ b/src/sql/query/field_scoring_validation_ctes.sql
@@ -55,7 +55,7 @@ raw_field_scoring_validation_errors AS (
     SELECT 80 AS priority,
            'field_b contains unknown field: ' || key AS message
     FROM field_b_entries
-    WHERE key NOT IN (SELECT field FROM {{fts_schema}}.fields)
+    WHERE key NOT IN (SELECT field FROM {{fts_schema}}.fields){{requested_fields_validation}}
 ),
 validation_errors AS (
     SELECT message

--- a/test/sql/fts/test_field_scoring.test
+++ b/test/sql/fts/test_field_scoring.test
@@ -381,6 +381,18 @@ SELECT * FROM fts_main_documents.search_layered_bm25('alpha', fields := 'missing
 ----
 fields contains unknown field: missing
 
+# A typo beside a valid name is the case that used to hide: 'title' alone still
+# matched, so the query returned results and the unknown name went unnoticed.
+statement error
+SELECT fts_main_documents.match_bm25('title_match', 'alpha', fields := 'title, missing')
+----
+fields contains unknown field: missing
+
+statement error
+SELECT * FROM fts_main_documents.search_layered_bm25('alpha', fields := 'title, missing')
+----
+fields contains unknown field: missing
+
 # 'fields' is reported before 'field_weights'.
 statement error
 SELECT fts_main_documents.match_bm25('title_match', 'alpha', fields := 'missing', field_weights := MAP {'absent': 1.0})

--- a/test/sql/fts/test_field_scoring.test
+++ b/test/sql/fts/test_field_scoring.test
@@ -370,6 +370,34 @@ SELECT * FROM fts_main_documents.search_layered_bm25('alpha', field_b := MAP {'m
 ----
 field_b contains unknown field: missing
 
+# An unknown name in 'fields' is rejected, like an unknown key in field_weights.
+statement error
+SELECT fts_main_documents.match_bm25('title_match', 'alpha', fields := 'missing')
+----
+fields contains unknown field: missing
+
+statement error
+SELECT * FROM fts_main_documents.search_layered_bm25('alpha', fields := 'missing')
+----
+fields contains unknown field: missing
+
+# 'fields' is reported before 'field_weights'.
+statement error
+SELECT fts_main_documents.match_bm25('title_match', 'alpha', fields := 'missing', field_weights := MAP {'absent': 1.0})
+----
+fields contains unknown field: missing
+
+# Known fields still resolve, and leaving the argument out searches all of them.
+query I
+SELECT fts_main_documents.match_bm25('title_match', 'alpha', fields := 'title, body') IS NOT NULL
+----
+true
+
+query I
+SELECT fts_main_documents.match_bm25('title_match', 'alpha', fields := NULL) IS NOT NULL
+----
+true
+
 # An initially empty incremental index acquires usable field averages on insert.
 statement ok
 CREATE TABLE initially_empty(id VARCHAR NOT NULL, title VARCHAR, body VARCHAR)


### PR DESCRIPTION
The `fields` argument silently ignores a name that is not an indexed field, so a typo returns an empty result instead of an error. `field_weights` and `field_b` both reject unknown names, and the structured query path already reports `fields contains unknown field: …` — this is the one place that stays quiet.

The README says unknown fields produce an error, so I treated this as a divergence rather than a new feature and left the docs alone.

The check goes in the shared validation CTE, so `match_bm25`, `search_layered_bm25` and `search_layered_pattern` are covered by one branch. The structured path opts out — it validates its own field list, and `test_boolean_query` already covers that. An empty `fields` is left alone, since `test_indexing` pins that searching no fields returns no rows.

One note on the report itself: the exact example in #21 works now, because `trim()` handles the spaces around `col_2`. The defect is the silent handling of a name that does not exist.

`fields` is split on commas and then trimmed, so a field whose name contains a comma or has surrounding whitespace cannot be named through it at all:

```sql
-- for a column named "a,b"
fields := 'a,b'         -- splits into 'a' and 'b', neither of which exists

-- for a column named " spaced "
fields := ' spaced '    -- trims to 'spaced', which does not exist either
```

That was already the case; this change makes both fail loudly rather than returning nothing, though the message then names the split-and-trimmed value rather than what was typed. Naming such a field would need a different shape for the argument, so I left it alone.

Fixes #21
