### PR TITLE
Fix validation skipped for unused docname

### DIFF
--- a/src/sql/query/search_layered_bm25.sql
+++ b/src/sql/query/search_layered_bm25.sql
@@ -613,8 +613,10 @@ results AS (
 SELECT *
 FROM results
 UNION ALL
-SELECT error(message)::VARCHAR AS docname,
+-- In a filter, not the projection: a projected error() is dropped when docname is unused.
+SELECT NULL::VARCHAR AS docname,
        NULL::DOUBLE AS score,
        NULL::BIGINT AS rank
 FROM search_validation_errors
+WHERE error(message)
 ORDER BY rank;

--- a/src/sql/query/search_layered_pattern.sql
+++ b/src/sql/query/search_layered_pattern.sql
@@ -144,8 +144,10 @@ results AS (
 SELECT *
 FROM results
 UNION ALL
-SELECT error(message)::VARCHAR AS docname,
+SELECT NULL::VARCHAR AS docname,
        NULL::DOUBLE AS score,
        NULL::BIGINT AS rank
 FROM search_validation_errors
+-- In a filter, not the projection: a projected error() is dropped when docname is unused.
+WHERE error(message)
 ORDER BY rank;

--- a/test/sql/fts/test_boolean_query.test
+++ b/test/sql/fts/test_boolean_query.test
@@ -564,6 +564,12 @@ SELECT * FROM fts_main_boolean_docs.search_layered_bm25_query('{"query":"alpha",
 ----
 fields contains unknown field: missing
 
+# An invalid field is reported even when no column of the result is read.
+statement error
+SELECT count(*) FROM fts_main_boolean_docs.search_layered_bm25_query('{"query":"alpha","fields":["missing"]}'::JSON)
+----
+fields contains unknown field: missing
+
 statement error
 SELECT * FROM fts_main_boolean_docs.search_layered_bm25_query('{"query":"alpha","query_mode":"invalid"}'::JSON)
 ----

--- a/test/sql/fts/test_field_scoring.test
+++ b/test/sql/fts/test_field_scoring.test
@@ -397,6 +397,18 @@ SELECT EXISTS (SELECT 1 FROM fts_main_documents.search_layered_bm25('alpha', fie
 ----
 fields contains unknown field: missing
 
+# The scalar surface reports it too when its result is discarded.
+statement error
+SELECT count(*) FROM (SELECT fts_main_documents.match_bm25(id, 'alpha', fields := 'missing') AS unused FROM documents)
+----
+fields contains unknown field: missing
+
+# A provably empty query is not executed, so it reports nothing.
+query I
+SELECT count(*) FROM fts_main_documents.search_layered_bm25('alpha', fields := 'missing') WHERE false
+----
+0
+
 # An unknown name in 'fields' is rejected, like an unknown key in field_weights.
 statement error
 SELECT fts_main_documents.match_bm25('title_match', 'alpha', fields := 'missing')

--- a/test/sql/fts/test_field_scoring.test
+++ b/test/sql/fts/test_field_scoring.test
@@ -370,6 +370,33 @@ SELECT * FROM fts_main_documents.search_layered_bm25('alpha', field_b := MAP {'m
 ----
 field_b contains unknown field: missing
 
+# Validation does not depend on the shape of the caller's query.
+statement error
+SELECT count(*) FROM fts_main_documents.search_layered_bm25('alpha', b := 5.0)
+----
+b must be finite and between 0 and 1
+
+statement error
+SELECT score FROM fts_main_documents.search_layered_bm25('alpha', fields := 'missing')
+----
+fields contains unknown field: missing
+
+statement error
+SELECT count(*) FROM fts_main_documents.search_layered_bm25('al*', query_mode := 'wildcard', fields := 'missing')
+----
+fields contains unknown field: missing
+
+# The filter does not fire on a valid query.
+query I
+SELECT count(*) > 0 FROM fts_main_documents.search_layered_bm25('alpha', b := 0.75)
+----
+true
+
+statement error
+SELECT EXISTS (SELECT 1 FROM fts_main_documents.search_layered_bm25('alpha', fields := 'missing'))
+----
+fields contains unknown field: missing
+
 # An unknown name in 'fields' is rejected, like an unknown key in field_weights.
 statement error
 SELECT fts_main_documents.match_bm25('title_match', 'alpha', fields := 'missing')


### PR DESCRIPTION
Fixes #54.

A filter decides how many rows its `SELECT` contributes, so the optimizer cannot drop it. That is why this position works where the previous one did not, and the codebase already relies on it: `query_mode` is checked inside the `params` CTE, whose value the rest of the query consumes, and it has never been affected.

The README documents these as errors, so I would rather the check not depend on which columns a caller happens to read, whichever way the optimizer treats an unused projection.

Both files change the same way, so `search_layered_bm25` now agrees with the scalar macros on every query shape that executes.

The first commit carries the change and the tests that fail without it: `count(*)`, `SELECT score` and `EXISTS` against `search_layered_bm25`, the `wildcard` path for the pattern file, and one that a valid query still returns rows, so the new filter cannot fire unconditionally. Reverting only the two SQL files makes each of them fail on its own.

The second commit adds coverage for behaviour this change must not alter: the scalar macro still reports an invalid field when its result is discarded, the structured surface does the same, and `WHERE false` still returns `0`. Those pass with and without the change, which is why they are separate.

`LIMIT 0` and `WHERE false` return without an error because neither executes the query, and that matches what the scalar macros already do.
