### PR TITLE
Add near-mode proximity search with an FTS5 distance bound

### DIFF
--- a/.github/regression/fts_near.csv
+++ b/.github/regression/fts_near.csv
@@ -1,0 +1,4 @@
+benchmark/fts/layered_autocomplete/smoke/near_adjacent.benchmark
+benchmark/fts/layered_autocomplete/smoke/near_reversed.benchmark
+benchmark/fts/layered_autocomplete/smoke/near_common.benchmark
+benchmark/fts/layered_autocomplete/smoke/near_dense_unbounded.benchmark

--- a/.github/regression/fts_near_haystack.csv
+++ b/.github/regression/fts_near_haystack.csv
@@ -1,0 +1,4 @@
+benchmark/fts/layered_autocomplete/haystack/near_adjacent.benchmark
+benchmark/fts/layered_autocomplete/haystack/near_reversed.benchmark
+benchmark/fts/layered_autocomplete/haystack/near_common.benchmark
+benchmark/fts/layered_autocomplete/haystack/near_dense_unbounded.benchmark

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -144,6 +144,7 @@ jobs:
               echo "PHRASE_BENCHMARKS=.github/regression/fts_phrase_haystack.csv"
               echo "ANALYZER_BENCHMARKS=.github/regression/fts_analyzer_haystack.csv"
               echo "PATTERN_BENCHMARKS=.github/regression/fts_pattern_haystack.csv"
+              echo "NEAR_BENCHMARKS=.github/regression/fts_near_haystack.csv"
               echo "FOOTPRINT_ROWS=1000000"
               echo "BENCHMARK_BUDGET_SECONDS=3600"
             } >> "$GITHUB_ENV"
@@ -156,6 +157,7 @@ jobs:
               echo "PHRASE_BENCHMARKS=.github/regression/fts_phrase.csv"
               echo "ANALYZER_BENCHMARKS=.github/regression/fts_analyzer.csv"
               echo "PATTERN_BENCHMARKS=.github/regression/fts_pattern.csv"
+              echo "NEAR_BENCHMARKS=.github/regression/fts_near.csv"
               echo "FOOTPRINT_ROWS=50000"
               echo "BENCHMARK_BUDGET_SECONDS=600"
             } >> "$GITHUB_ENV"
@@ -236,10 +238,20 @@ jobs:
               --clear-benchmark-cache \
               --nofail \
               --verbose 2>&1 | tee pattern-smoke.log
+
+            python3 duckdb/scripts/regression/test_runner.py \
+              --old "$NEW_RUNNER" \
+              --new "$NEW_RUNNER" \
+              --benchmarks "$NEAR_BENCHMARKS" \
+              --root-dir . \
+              --threads 2 \
+              --clear-benchmark-cache \
+              --nofail \
+              --verbose 2>&1 | tee near-smoke.log
           }
 
           export -f run_benchmarks
-          export OLD_RUNNER NEW_RUNNER LAYERED_BENCHMARKS AUTOCOMPLETE_BENCHMARKS FIELD_SCORING_BENCHMARKS BOOLEAN_BENCHMARKS PHRASE_BENCHMARKS ANALYZER_BENCHMARKS PATTERN_BENCHMARKS
+          export OLD_RUNNER NEW_RUNNER LAYERED_BENCHMARKS AUTOCOMPLETE_BENCHMARKS FIELD_SCORING_BENCHMARKS BOOLEAN_BENCHMARKS PHRASE_BENCHMARKS ANALYZER_BENCHMARKS PATTERN_BENCHMARKS NEAR_BENCHMARKS
           timeout "${BENCHMARK_BUDGET_SECONDS}s" bash -c run_benchmarks
 
       - name: Report positional index footprint
@@ -283,6 +295,10 @@ jobs:
             echo '```text'
             test ! -f pattern-smoke.log || cat pattern-smoke.log
             echo '```'
+            echo '## FTS near-query smoke'
+            echo '```text'
+            test ! -f near-smoke.log || cat near-smoke.log
+            echo '```'
             echo '## FTS positional index footprint'
             echo '```text'
             test ! -f phrase-footprint.log || cat phrase-footprint.log
@@ -302,5 +318,6 @@ jobs:
             phrase-regression.log
             analyzer-smoke.log
             pattern-smoke.log
+            near-smoke.log
             phrase-footprint.log
           if-no-files-found: ignore

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ set(EXTENSION_SOURCES
     ${EXTENSION_BASE_FOLDER}/fts_index_common.cpp
     ${EXTENSION_BASE_FOLDER}/fts_index_maintenance.cpp
     ${EXTENSION_BASE_FOLDER}/fts_indexing.cpp
+    ${EXTENSION_BASE_FOLDER}/fts_near.cpp
     ${EXTENSION_BASE_FOLDER}/fts_pattern.cpp
     ${EXTENSION_BASE_FOLDER}/fts_sql_template.cpp
     ${EXTENSION_BASE_FOLDER}/fts_unicode_classifier.cpp

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ When an index is built, this retrieval macro is created that can be used to sear
 | `field_b` | `MAP(VARCHAR, DOUBLE)` | Per-field BM25 length-normalization parameters. Values must be between `0.0` and `1.0`; omitted fields inherit `b`. Defaults to `NULL` |
 | `scoring_model` | `VARCHAR` | Field scoring model: `bm25f` or `best_fields`. Defaults to `bm25f` |
 | `tie_breaker` | `DOUBLE` | Contribution from non-best fields in `best_fields` mode. Must be finite and between `0.0` and `1.0`. Defaults to `0.0` |
+| `near_distance` | `BIGINT` | Tokens permitted between the first and the last query term in `near` mode, ignored otherwise. Must be a non-negative integer. Counted once across the whole match, and intervening query terms count toward it. `0` means the terms are consecutive. This is `NEAR` `N` from SQLite's FTS5, and shares its default of `10` |
 
 BM25F is the default for both single-field and multi-field indexes. It
 normalizes term frequency independently for each selected field, combines those
@@ -146,7 +147,7 @@ search_layered_bm25(query_string, fields := NULL, top_k := 50, k := 1.2,
                     enable_short_fuzzy := true, expand_exact_terms := false,
                     query_mode := 'standard', field_weights := NULL,
                     field_b := NULL, scoring_model := 'bm25f',
-                    tie_breaker := 0.0)
+                    tie_breaker := 0.0, near_distance := 10)
 
 match_layered_bm25(input_id, query_string, fields := NULL, k := 1.2,
                    b := 0.75, term_limit := 32, max_df_ratio := 0.15,
@@ -155,7 +156,7 @@ match_layered_bm25(input_id, query_string, fields := NULL, k := 1.2,
                    enable_short_fuzzy := true, expand_exact_terms := false,
                    query_mode := 'standard', field_weights := NULL,
                    field_b := NULL, scoring_model := 'bm25f',
-                   tie_breaker := 0.0)
+                   tie_breaker := 0.0, near_distance := 10)
 ```
 
 When `layered_search` is enabled, the extension builds dictionary sidecar
@@ -186,7 +187,6 @@ filtering, and BM25 parameters as the base FTS index.
 | `enable_fuzzy` | `BOOLEAN` | Whether to include Damerau-Levenshtein fuzzy alternatives. Defaults to `true` |
 | `enable_short_fuzzy` | `BOOLEAN` | Whether to use a length-clustered path for short fuzzy alternatives. Defaults to `true` |
 | `expand_exact_terms` | `BOOLEAN` | Whether to also expand a query term that already has an exact dictionary match. Defaults to `false` |
-| `near_distance` | `BIGINT` | Tokens permitted between the first and the last query term in `near` mode, ignored otherwise. Must be a non-negative integer. Counted once across the whole match, and intervening query terms count toward it. `0` means the terms are consecutive. This is `NEAR` `N` from SQLite's FTS5, and shares its default of `10` |
 | `query_mode` | `VARCHAR` | Query execution mode. `standard` uses exact, prefix, substring, and fuzzy dictionary expansion; `autocomplete` keeps preceding tokens exact and matches the final token by raw-token prefix; `phrase` requires exact order and adjacency; `phrase_prefix` treats the final phrase token as a raw-token prefix; `near` requires every term in one field within `near_distance` tokens of each other, in any order; `wildcard` matches `*` and `?` patterns; `regex` matches a conservative flat RE2 subset. Defaults to `standard` |
 | `field_weights` | `MAP(VARCHAR, DOUBLE)` | Non-negative finite weights for indexed fields. Omitted fields have weight `1.0`. Defaults to `NULL` |
 | `field_b` | `MAP(VARCHAR, DOUBLE)` | Per-field BM25 length-normalization parameters. Values must be between `0.0` and `1.0`; omitted fields inherit `b`. Defaults to `NULL` |

--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ When an index is built, this retrieval macro is created that can be used to sear
 | `field_b` | `MAP(VARCHAR, DOUBLE)` | Per-field BM25 length-normalization parameters. Values must be between `0.0` and `1.0`; omitted fields inherit `b`. Defaults to `NULL` |
 | `scoring_model` | `VARCHAR` | Field scoring model: `bm25f` or `best_fields`. Defaults to `bm25f` |
 | `tie_breaker` | `DOUBLE` | Contribution from non-best fields in `best_fields` mode. Must be finite and between `0.0` and `1.0`. Defaults to `0.0` |
-| `near_distance` | `BIGINT` | Tokens permitted between the first and the last query term in `near` mode, ignored otherwise. Must be a non-negative integer. Counted once across the whole match, and intervening query terms count toward it. `0` means the terms are consecutive. This is `NEAR` `N` from SQLite's FTS5, and shares its default of `10` |
 
 BM25F is the default for both single-field and multi-field indexes. It
 normalizes term frequency independently for each selected field, combines those
@@ -192,6 +191,7 @@ filtering, and BM25 parameters as the base FTS index.
 | `field_b` | `MAP(VARCHAR, DOUBLE)` | Per-field BM25 length-normalization parameters. Values must be between `0.0` and `1.0`; omitted fields inherit `b`. Defaults to `NULL` |
 | `scoring_model` | `VARCHAR` | Field scoring model: `bm25f` or `best_fields`. Defaults to `bm25f` |
 | `tie_breaker` | `DOUBLE` | Contribution from non-best fields in `best_fields` mode. Must be finite and between `0.0` and `1.0`. Defaults to `0.0` |
+| `near_distance` | `BIGINT` | Tokens permitted between the first and the last query term in `near` mode, ignored otherwise. Must be a non-negative integer. Counted once across the whole match, and intervening query terms count toward it. `0` means the terms are consecutive. This is `NEAR` `N` from SQLite's FTS5, and shares its default of `10` |
 
 <!-- markdownlint-enable MD056 -->
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ create_fts_index(input_table, input_id, *input_values, stemmer = 'porter',
 | `overwrite` | `BOOLEAN` | Whether to overwrite an existing index on a table. Defaults to `0` |
 | `incremental` | `BOOLEAN` | Whether to maintain the FTS index with triggers after inserts and deletes on the input table. Defaults to `0` |
 | `cluster_terms` | `BOOLEAN` | Whether to physically order the generated `terms` table by `termid`, `fieldid`, and `docid`. This can improve query-time pruning for direct reads from the FTS tables. Defaults to `0` |
-| `layered_search` | `BOOLEAN` | Whether to build the dictionary sidecars, positional postings, and layered search macros used by expanded, autocomplete, phrase, phrase-prefix, wildcard, and regex queries. This implies `cluster_terms`. Defaults to `0` |
+| `layered_search` | `BOOLEAN` | Whether to build the dictionary sidecars, positional postings, and layered search macros used by expanded, autocomplete, phrase, phrase-prefix, near, wildcard, and regex queries. This implies `cluster_terms`. Defaults to `0` |
 
 <!-- markdownlint-enable MD056 -->
 
@@ -186,7 +186,8 @@ filtering, and BM25 parameters as the base FTS index.
 | `enable_fuzzy` | `BOOLEAN` | Whether to include Damerau-Levenshtein fuzzy alternatives. Defaults to `true` |
 | `enable_short_fuzzy` | `BOOLEAN` | Whether to use a length-clustered path for short fuzzy alternatives. Defaults to `true` |
 | `expand_exact_terms` | `BOOLEAN` | Whether to also expand a query term that already has an exact dictionary match. Defaults to `false` |
-| `query_mode` | `VARCHAR` | Query execution mode. `standard` uses exact, prefix, substring, and fuzzy dictionary expansion; `autocomplete` keeps preceding tokens exact and matches the final token by raw-token prefix; `phrase` requires exact order and adjacency; `phrase_prefix` treats the final phrase token as a raw-token prefix; `wildcard` matches `*` and `?` patterns; `regex` matches a conservative flat RE2 subset. Defaults to `standard` |
+| `near_distance` | `BIGINT` | Tokens permitted between the first and the last query term in `near` mode, ignored otherwise. Must be a non-negative integer. Counted once across the whole match, and intervening query terms count toward it. `0` means the terms are consecutive. This is `NEAR` `N` from SQLite's FTS5, and shares its default of `10` |
+| `query_mode` | `VARCHAR` | Query execution mode. `standard` uses exact, prefix, substring, and fuzzy dictionary expansion; `autocomplete` keeps preceding tokens exact and matches the final token by raw-token prefix; `phrase` requires exact order and adjacency; `phrase_prefix` treats the final phrase token as a raw-token prefix; `near` requires every term in one field within `near_distance` tokens of each other, in any order; `wildcard` matches `*` and `?` patterns; `regex` matches a conservative flat RE2 subset. Defaults to `standard` |
 | `field_weights` | `MAP(VARCHAR, DOUBLE)` | Non-negative finite weights for indexed fields. Omitted fields have weight `1.0`. Defaults to `NULL` |
 | `field_b` | `MAP(VARCHAR, DOUBLE)` | Per-field BM25 length-normalization parameters. Values must be between `0.0` and `1.0`; omitted fields inherit `b`. Defaults to `NULL` |
 | `scoring_model` | `VARCHAR` | Field scoring model: `bm25f` or `best_fields`. Defaults to `bm25f` |
@@ -224,6 +225,19 @@ unfinished raw token through the prefix sidecar. `term_limit` bounds those
 deterministically ordered completions; document-frequency filters and fuzzy or
 substring expansion are not applied. A one-token phrase uses standard mode,
 while a one-token phrase-prefix uses autocomplete mode.
+
+Near mode uses the same positional postings to require that every query term
+occurs in one indexed field, in any order, with at most `near_distance` tokens
+between the first and the last of them. The distance is counted once across the
+whole match rather than for each pair, and intervening query terms count toward
+it, so two terms need `near_distance = 0` to be adjacent while three consecutive
+terms need `1`. As in phrase mode, removed stopwords retain their positional gap, so a
+stopword between two terms consumes distance. A term repeated in the query
+counts once, and quoted phrases are not supported; the query is a set of
+distinct terms. Near mode matches exact dictionary terms, so prefix, fuzzy, and
+substring expansion are not applied, and a term that occurs in no document
+disqualifies every document. `near_distance` is `NEAR` `N` from SQLite's FTS5
+and shares its default of `10`.
 
 Wildcard and regex modes treat the complete `query_string` as one whole-token
 pattern and match it verbatim against the normalized raw-term dictionary.

--- a/README.md
+++ b/README.md
@@ -354,10 +354,12 @@ are added and then multiplied by the group's optional `boost`. Leaf boosts are
 applied to the leaf BM25 score first.
 
 Leaves can select indexed fields with a JSON string array and choose
-`standard`, `autocomplete`, `phrase`, `phrase_prefix`, `wildcard`, or `regex`
-query mode independently. Expansion controls and field scoring configuration
-remain macro-level settings so all leaves share the same resource limits and
-field model. `scoring_model := 'bm25f'` uses canonical BM25F with optional
+`standard`, `autocomplete`, `phrase`, `phrase_prefix`, `near`, `wildcard`, or
+`regex` query mode independently. A `near` leaf takes its own optional
+`near_distance`, so one clause can require proximity while another does not.
+Expansion controls and field scoring configuration remain macro-level settings
+so all leaves share the same resource limits and field model.
+`scoring_model := 'bm25f'` uses canonical BM25F with optional
 `field_weights` and per-field length normalization through `field_b`;
 `best_fields` selects the strongest field and optionally incorporates the
 others through `tie_breaker`. Ordinary leaves reuse the non-pattern layered

--- a/benchmark/fts/layered_autocomplete/haystack/near_adjacent.benchmark
+++ b/benchmark/fts/layered_autocomplete/haystack/near_adjacent.benchmark
@@ -1,0 +1,5 @@
+template benchmark/fts/layered_autocomplete/templates/near_query.benchmark.in
+display_name=FTS adjacent near query (1M)
+rows=1000000
+query_string=southstar infixalpha
+near_distance=0

--- a/benchmark/fts/layered_autocomplete/haystack/near_common.benchmark
+++ b/benchmark/fts/layered_autocomplete/haystack/near_common.benchmark
@@ -1,0 +1,5 @@
+template benchmark/fts/layered_autocomplete/templates/near_query.benchmark.in
+display_name=FTS common near query (1M)
+rows=1000000
+query_string=workspace benchmark
+near_distance=2

--- a/benchmark/fts/layered_autocomplete/haystack/near_dense_unbounded.benchmark
+++ b/benchmark/fts/layered_autocomplete/haystack/near_dense_unbounded.benchmark
@@ -1,0 +1,5 @@
+template benchmark/fts/layered_autocomplete/templates/near_dense.benchmark.in
+display_name=FTS dense unbounded near query (1000x4K)
+rows=1000
+tokens=4000
+near_distance=9223372036854775807

--- a/benchmark/fts/layered_autocomplete/haystack/near_reversed.benchmark
+++ b/benchmark/fts/layered_autocomplete/haystack/near_reversed.benchmark
@@ -1,0 +1,5 @@
+template benchmark/fts/layered_autocomplete/templates/near_query.benchmark.in
+display_name=FTS reversed near query (1M)
+rows=1000000
+query_string=infixalpha southstar
+near_distance=0

--- a/benchmark/fts/layered_autocomplete/smoke/near_adjacent.benchmark
+++ b/benchmark/fts/layered_autocomplete/smoke/near_adjacent.benchmark
@@ -1,0 +1,5 @@
+template benchmark/fts/layered_autocomplete/templates/near_query.benchmark.in
+display_name=FTS adjacent near query (50K)
+rows=50000
+query_string=southstar infixalpha
+near_distance=0

--- a/benchmark/fts/layered_autocomplete/smoke/near_common.benchmark
+++ b/benchmark/fts/layered_autocomplete/smoke/near_common.benchmark
@@ -1,0 +1,5 @@
+template benchmark/fts/layered_autocomplete/templates/near_query.benchmark.in
+display_name=FTS common near query (50K)
+rows=50000
+query_string=workspace benchmark
+near_distance=2

--- a/benchmark/fts/layered_autocomplete/smoke/near_dense_unbounded.benchmark
+++ b/benchmark/fts/layered_autocomplete/smoke/near_dense_unbounded.benchmark
@@ -1,0 +1,5 @@
+template benchmark/fts/layered_autocomplete/templates/near_dense.benchmark.in
+display_name=FTS dense unbounded near query (200x4K)
+rows=200
+tokens=4000
+near_distance=9223372036854775807

--- a/benchmark/fts/layered_autocomplete/smoke/near_reversed.benchmark
+++ b/benchmark/fts/layered_autocomplete/smoke/near_reversed.benchmark
@@ -1,0 +1,5 @@
+template benchmark/fts/layered_autocomplete/templates/near_query.benchmark.in
+display_name=FTS reversed near query (50K)
+rows=50000
+query_string=infixalpha southstar
+near_distance=0

--- a/benchmark/fts/layered_autocomplete/templates/near_dense.benchmark.in
+++ b/benchmark/fts/layered_autocomplete/templates/near_dense.benchmark.in
@@ -1,0 +1,39 @@
+name ${display_name}
+group fts
+subgroup near-query
+
+require fts
+
+init
+CREATE TABLE documents(id VARCHAR NOT NULL, body VARCHAR);
+INSERT INTO documents
+SELECT 'doc' || lpad(i::VARCHAR, 12, '0') AS id,
+       dense.body AS body
+FROM range(${rows}) AS source(i)
+CROSS JOIN (
+    SELECT string_agg(CASE WHEN j % 2 = 0 THEN 'northstar' ELSE 'southstar' END, ' ') AS body
+    FROM range(${tokens}) AS gaps(j)
+) AS dense;
+
+load
+PRAGMA create_fts_index('documents', 'id', 'body', stemmer='porter', stopwords='none', layered_search=true, incremental=true);
+
+assert I
+SELECT count(*) > 0
+FROM fts_main_documents.search_layered_bm25(
+    'northstar southstar',
+    top_k := 50,
+    query_mode := 'near',
+    near_distance := ${near_distance}
+)
+----
+true
+
+run
+SELECT docname, score, rank
+FROM fts_main_documents.search_layered_bm25(
+    'northstar southstar',
+    top_k := 50,
+    query_mode := 'near',
+    near_distance := ${near_distance}
+);

--- a/benchmark/fts/layered_autocomplete/templates/near_query.benchmark.in
+++ b/benchmark/fts/layered_autocomplete/templates/near_query.benchmark.in
@@ -1,0 +1,46 @@
+name ${display_name}
+group fts
+subgroup near-query
+
+require fts
+
+init
+CREATE TABLE documents(id VARCHAR NOT NULL, title VARCHAR, body VARCHAR);
+INSERT INTO documents
+SELECT 'doc' || lpad(i::VARCHAR, 12, '0') AS id,
+       'record category' || (i % 100)::VARCHAR || ' region' || (i % 20)::VARCHAR AS title,
+       'workspace item search benchmark ' ||
+           CASE i % 20
+               WHEN 0 THEN 'northstar prefixalpha northstar prefixalpha running'
+               WHEN 1 THEN 'northstar prefixbeta runner'
+               WHEN 2 THEN 'southstar infixalpha runnable'
+               WHEN 3 THEN 'eaststar prefixgamma running'
+               WHEN 4 THEN 'weststar infixbeta runner'
+               ELSE 'baseline catalog archive'
+           END || ' ' || substr(md5(i::VARCHAR), 1, 16) AS body
+FROM range(${rows}) AS source(i);
+
+load
+PRAGMA create_fts_index('documents', 'id', 'title', 'body', stemmer='porter', stopwords='none', layered_search=true, incremental=true);
+
+assert I
+SELECT count(*) > 0
+FROM fts_main_documents.search_layered_bm25(
+    '${query_string}',
+    fields := 'body',
+    top_k := 50,
+    query_mode := 'near',
+    near_distance := ${near_distance}
+)
+----
+true
+
+run
+SELECT docname, score, rank
+FROM fts_main_documents.search_layered_bm25(
+    '${query_string}',
+    fields := 'body',
+    top_k := 50,
+    query_mode := 'near',
+    near_distance := ${near_distance}
+);

--- a/src/fts_extension.cpp
+++ b/src/fts_extension.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "fts_indexing.hpp"
+#include "fts_near.hpp"
 #include "fts_pattern.hpp"
 #include "fts_unicode_classifier.hpp"
 #include "libstemmer.h"
@@ -234,6 +235,7 @@ static void LoadInternal(ExtensionLoader &loader) {
   loader.RegisterFunction(stem_func);
   loader.RegisterFunction(opensearch_standard_tokenize_func);
   loader.RegisterFunction(GetFTSAnalyzePatternFunction());
+  loader.RegisterFunction(GetFTSNearTfFunction());
   loader.RegisterFunction(create_fts_index_func);
   loader.RegisterFunction(create_fts_boolean_query_macros_func);
   loader.RegisterFunction(drop_fts_index_func);

--- a/src/fts_near.cpp
+++ b/src/fts_near.cpp
@@ -1,0 +1,141 @@
+#include "fts_near.hpp"
+
+#include "duckdb/common/vector/vector_writer.hpp"
+
+namespace duckdb {
+
+// Positions arrive unordered with the term id of each posting; the result is
+// the smallest per-term count of positions within width of a match end.
+static int64_t NearTf(const vector<int64_t> &positions,
+                      const vector<int64_t> &term_ids, int64_t slot_count,
+                      int64_t width) {
+  if (slot_count <= 0 || width < 0) {
+    return 0;
+  }
+  vector<std::pair<int64_t, int64_t>> postings;
+  postings.reserve(positions.size());
+  for (idx_t i = 0; i < positions.size(); i++) {
+    postings.emplace_back(positions[i], term_ids[i]);
+  }
+  std::sort(postings.begin(), postings.end());
+  vector<int64_t> unique_ids;
+  vector<idx_t> slots;
+  slots.reserve(postings.size());
+  for (const auto &posting : postings) {
+    auto term_id = posting.second;
+    idx_t slot = unique_ids.size();
+    for (idx_t known = 0; known < unique_ids.size(); known++) {
+      if (unique_ids[known] == term_id) {
+        slot = known;
+        break;
+      }
+    }
+    if (slot == unique_ids.size()) {
+      unique_ids.push_back(term_id);
+    }
+    slots.push_back(slot);
+  }
+  if (NumericCast<int64_t>(unique_ids.size()) < slot_count) {
+    return 0;
+  }
+  auto found_count = unique_ids.size();
+  vector<int64_t> last(found_count, NumericLimits<int64_t>::Minimum());
+  vector<int64_t> ends;
+  idx_t filled = 0;
+  for (idx_t i = 0; i < postings.size(); i++) {
+    if (last[slots[i]] == NumericLimits<int64_t>::Minimum()) {
+      filled++;
+    }
+    last[slots[i]] = postings[i].first;
+    if (filled < found_count) {
+      continue;
+    }
+    auto min_last = last[0];
+    for (idx_t s = 1; s < found_count; s++) {
+      min_last = MinValue(min_last, last[s]);
+    }
+    if (min_last >= postings[i].first - width) {
+      ends.push_back(postings[i].first);
+    }
+  }
+  if (ends.empty()) {
+    return 0;
+  }
+  vector<int64_t> matched(found_count, 0);
+  auto next_end = NumericLimits<int64_t>::Maximum();
+  idx_t end_index = ends.size();
+  for (idx_t i = postings.size(); i > 0; i--) {
+    auto position = postings[i - 1].first;
+    while (end_index > 0 && ends[end_index - 1] >= position) {
+      next_end = ends[end_index - 1];
+      end_index--;
+    }
+    if (next_end != NumericLimits<int64_t>::Maximum() &&
+        next_end - position <= width) {
+      matched[slots[i - 1]]++;
+    }
+  }
+  auto tf = matched[0];
+  for (idx_t s = 1; s < found_count; s++) {
+    tf = MinValue(tf, matched[s]);
+  }
+  return tf;
+}
+
+static void NearTfFunction(DataChunk &args, ExpressionState &state,
+                           Vector &result) {
+  auto position_lists = args.data[0].Values<VectorListType<int64_t>>();
+  auto term_id_lists = args.data[1].Values<VectorListType<int64_t>>();
+  auto slot_counts = args.data[2].Values<int64_t>();
+  auto widths = args.data[3].Values<int64_t>();
+
+  result.SetVectorType(VectorType::FLAT_VECTOR);
+  auto writer = FlatVector::Writer<int64_t>(result, args.size());
+  for (idx_t i = 0; i < args.size(); i++) {
+    auto position_entry = position_lists[i];
+    auto term_id_entry = term_id_lists[i];
+    auto slot_count = slot_counts[i];
+    auto width = widths[i];
+    if (!position_entry.IsValid() || !term_id_entry.IsValid() ||
+        !slot_count.IsValid() || !width.IsValid()) {
+      writer.WriteNull();
+      continue;
+    }
+    vector<int64_t> positions;
+    vector<int64_t> term_ids;
+    positions.reserve(position_entry.GetListLength());
+    term_ids.reserve(term_id_entry.GetListLength());
+    bool entries_valid = true;
+    for (const auto value : position_entry.GetChildValues()) {
+      if (!value.IsValid()) {
+        entries_valid = false;
+        break;
+      }
+      positions.push_back(value.GetValue());
+    }
+    for (const auto value : term_id_entry.GetChildValues()) {
+      if (!value.IsValid()) {
+        entries_valid = false;
+        break;
+      }
+      term_ids.push_back(value.GetValue());
+    }
+    if (!entries_valid || positions.size() != term_ids.size()) {
+      writer.WriteNull();
+      continue;
+    }
+    writer.WriteValue(
+        NearTf(positions, term_ids, slot_count.GetValue(), width.GetValue()));
+  }
+}
+
+ScalarFunction GetFTSNearTfFunction() {
+  ScalarFunction function("fts_near_tf",
+                          {LogicalType::LIST(LogicalType::BIGINT),
+                           LogicalType::LIST(LogicalType::BIGINT),
+                           LogicalType::BIGINT, LogicalType::BIGINT},
+                          LogicalType::BIGINT, NearTfFunction);
+  return function;
+}
+
+} // namespace duckdb

--- a/src/include/fts_near.hpp
+++ b/src/include/fts_near.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "duckdb/function/scalar_function.hpp"
+
+namespace duckdb {
+
+ScalarFunction GetFTSNearTfFunction();
+
+} // namespace duckdb

--- a/src/sql/query/match_layered_bm25.sql
+++ b/src/sql/query/match_layered_bm25.sql
@@ -1,4 +1,4 @@
-CREATE MACRO {{fts_schema}}.match_layered_bm25(input_id, query_string, fields := NULL, k := 1.2, b := 0.75, term_limit := 32, max_df_ratio := 0.15, max_df := 50000, enable_prefix := true, enable_substring := true, enable_fuzzy := true, enable_short_fuzzy := true, expand_exact_terms := false, query_mode := 'standard', near_distance := 10, field_weights := NULL, field_b := NULL, scoring_model := 'bm25f', tie_breaker := 0.0) AS (
+CREATE MACRO {{fts_schema}}.match_layered_bm25(input_id, query_string, fields := NULL, k := 1.2, b := 0.75, term_limit := 32, max_df_ratio := 0.15, max_df := 50000, enable_prefix := true, enable_substring := true, enable_fuzzy := true, enable_short_fuzzy := true, expand_exact_terms := false, query_mode := 'standard', field_weights := NULL, field_b := NULL, scoring_model := 'bm25f', tie_breaker := 0.0, near_distance := 10) AS (
     SELECT score
     FROM {{fts_schema}}.search_layered_bm25(
         query_string,

--- a/src/sql/query/match_layered_bm25.sql
+++ b/src/sql/query/match_layered_bm25.sql
@@ -1,4 +1,4 @@
-CREATE MACRO {{fts_schema}}.match_layered_bm25(input_id, query_string, fields := NULL, k := 1.2, b := 0.75, term_limit := 32, max_df_ratio := 0.15, max_df := 50000, enable_prefix := true, enable_substring := true, enable_fuzzy := true, enable_short_fuzzy := true, expand_exact_terms := false, query_mode := 'standard', field_weights := NULL, field_b := NULL, scoring_model := 'bm25f', tie_breaker := 0.0) AS (
+CREATE MACRO {{fts_schema}}.match_layered_bm25(input_id, query_string, fields := NULL, k := 1.2, b := 0.75, term_limit := 32, max_df_ratio := 0.15, max_df := 50000, enable_prefix := true, enable_substring := true, enable_fuzzy := true, enable_short_fuzzy := true, expand_exact_terms := false, query_mode := 'standard', near_distance := 10, field_weights := NULL, field_b := NULL, scoring_model := 'bm25f', tie_breaker := 0.0) AS (
     SELECT score
     FROM {{fts_schema}}.search_layered_bm25(
         query_string,
@@ -14,6 +14,7 @@ CREATE MACRO {{fts_schema}}.match_layered_bm25(input_id, query_string, fields :=
         enable_fuzzy := enable_fuzzy,
         enable_short_fuzzy := enable_short_fuzzy,
         expand_exact_terms := expand_exact_terms,
+    near_distance := near_distance,
         query_mode := query_mode,
         field_weights := field_weights,
         field_b := field_b,

--- a/src/sql/query/search_layered_bm25.sql
+++ b/src/sql/query/search_layered_bm25.sql
@@ -1,5 +1,5 @@
-CREATE MACRO {{fts_schema}}.__search_layered_bm25_non_pattern(query_string, fields := NULL, top_k := 50, k := 1.2, b := 0.75, term_limit := 32, max_df_ratio := 0.15, max_df := 50000, enable_prefix := true, enable_substring := true, enable_fuzzy := true, enable_short_fuzzy := true, expand_exact_terms := false, query_mode := 'standard', field_weights := NULL, field_b := NULL, scoring_model := 'bm25f', tie_breaker := 0.0) AS TABLE
-WITH params(term_limit, max_df_ratio, max_df, enable_prefix, enable_substring, enable_fuzzy, enable_short_fuzzy, expand_exact_terms, query_mode, field_weights, field_b, scoring_model, tie_breaker, default_b) AS (
+CREATE MACRO {{fts_schema}}.__search_layered_bm25_non_pattern(query_string, fields := NULL, top_k := 50, k := 1.2, b := 0.75, term_limit := 32, max_df_ratio := 0.15, max_df := 50000, enable_prefix := true, enable_substring := true, enable_fuzzy := true, enable_short_fuzzy := true, expand_exact_terms := false, query_mode := 'standard', near_distance := 10, field_weights := NULL, field_b := NULL, scoring_model := 'bm25f', tie_breaker := 0.0) AS TABLE
+WITH params(term_limit, max_df_ratio, max_df, enable_prefix, enable_substring, enable_fuzzy, enable_short_fuzzy, expand_exact_terms, query_mode, near_distance, field_weights, field_b, scoring_model, tie_breaker, default_b) AS (
     SELECT term_limit::BIGINT,
            max_df_ratio::DOUBLE,
            max_df::BIGINT,
@@ -13,10 +13,12 @@ WITH params(term_limit, max_df_ratio, max_df, enable_prefix, enable_substring, e
                WHEN 'autocomplete' THEN 'autocomplete'
                WHEN 'phrase' THEN 'phrase'
                WHEN 'phrase_prefix' THEN 'phrase_prefix'
+               WHEN 'near' THEN 'near'
                WHEN 'wildcard' THEN 'wildcard'
                WHEN 'regex' THEN 'regex'
-               ELSE error('query_mode must be one of standard, autocomplete, phrase, phrase_prefix, wildcard, or regex')
+               ELSE error('query_mode must be one of standard, autocomplete, phrase, phrase_prefix, near, wildcard, or regex')
            END,
+           near_distance::BIGINT,
            field_weights::MAP(VARCHAR, DOUBLE),
            field_b::MAP(VARCHAR, DOUBLE),
            lower(scoring_model::VARCHAR),
@@ -28,16 +30,28 @@ search_validation_errors AS (
     SELECT message
     FROM (
         SELECT 10 AS priority,
-               'query_mode must be one of standard, autocomplete, phrase, phrase_prefix, wildcard, or regex' AS message
+               'query_mode must be one of standard, autocomplete, phrase, phrase_prefix, near, wildcard, or regex' AS message
         WHERE query_mode IS NULL
            OR lower(query_mode::VARCHAR) NOT IN (
                'standard',
                'autocomplete',
                'phrase',
                'phrase_prefix',
+               'near',
                'wildcard',
                'regex'
            )
+        UNION ALL
+        SELECT 20 AS priority,
+               'near_distance must be a non-negative integer' AS message
+        WHERE lower(coalesce(query_mode::VARCHAR, '')) = 'near'
+          AND (
+              near_distance IS NULL
+              OR try_cast(near_distance AS DOUBLE) IS NULL
+              OR try_cast(near_distance AS DOUBLE) < 0
+              OR try_cast(near_distance AS DOUBLE)
+                 <> floor(try_cast(near_distance AS DOUBLE))
+          )
         UNION ALL
         SELECT 30 AS priority,
                message
@@ -81,6 +95,9 @@ query_shape AS (
                WHEN params.query_mode = 'phrase_prefix'
                 AND count(*) = 1
                    THEN 'autocomplete'
+               WHEN params.query_mode = 'near'
+                AND count(*) = 1
+                   THEN 'standard'
                ELSE params.query_mode
            END AS effective_mode
     FROM query_analyzer_tokens
@@ -519,6 +536,83 @@ phrase_field_term_tf AS (
     GROUP BY phrase_matches.docid,
              phrase_matches.fieldid
 ),
+fts_extension_autoload AS (
+    -- Bind DuckDB's stable FTS autoload entry before the near scan.
+    SELECT stem('', 'none') AS marker
+),
+near_slots AS (
+    -- One slot per distinct query term, so a repeated term adds its IDF once.
+    SELECT min(query_analyzer_tokens.token_position) AS slot,
+           term_stats.termid,
+           any_value(term_stats.df) AS df
+    FROM query_analyzer_tokens
+    JOIN {{fts_schema}}.term_stats AS term_stats
+      ON term_stats.term = query_analyzer_tokens.term
+    CROSS JOIN query_shape
+    WHERE query_shape.effective_mode = 'near'
+    GROUP BY term_stats.termid
+),
+near_slot_count AS (
+    -- Counted over query terms, not found ones: an absent term must leave a slot no posting can fill.
+    SELECT count(DISTINCT query_analyzer_tokens.term)::BIGINT AS slot_count
+    FROM query_analyzer_tokens
+    CROSS JOIN query_shape
+    WHERE query_shape.effective_mode = 'near'
+),
+near_window AS (
+    -- near_distance excludes the first and last term, so the span is near_distance + 1; the cap keeps it inside INT64.
+    SELECT least(greatest(params.near_distance, 0), 4611686018427387903) + 1 AS width
+    FROM params
+),
+near_grouped AS (
+    SELECT terms.docid,
+           terms.fieldid,
+           list(terms.position::BIGINT) AS positions,
+           list(near_slots.termid) AS termids
+    FROM near_slots
+    JOIN {{fts_schema}}.terms AS terms
+      ON terms.termid = near_slots.termid
+    WHERE terms.fieldid IN (SELECT fieldid FROM field_config)
+    GROUP BY terms.docid,
+             terms.fieldid
+),
+near_idf AS (
+    SELECT sum(
+               log(((((stats.num_docs - near_slots.df) + 0.5) / (near_slots.df + 0.5)) + 1))
+           ) AS near_idf
+    FROM near_slots
+    CROSS JOIN {{fts_schema}}.stats AS stats
+),
+near_field_term_tf AS (
+    SELECT scored.termid,
+           scored.rawtermid,
+           scored.docid,
+           scored.fieldid,
+           scored.idf,
+           scored.expansion_weight,
+           scored.tf
+    FROM (
+        SELECT NULL::BIGINT AS termid,
+               NULL::BIGINT AS rawtermid,
+               near_grouped.docid,
+               near_grouped.fieldid,
+               near_idf.near_idf AS idf,
+               1.0::DOUBLE AS expansion_weight,
+               fts_near_tf(
+                   near_grouped.positions,
+                   near_grouped.termids,
+                   near_slot_count.slot_count,
+                   near_window.width
+               )::DOUBLE AS tf
+        FROM near_grouped
+        CROSS JOIN fts_extension_autoload
+        CROSS JOIN near_slot_count
+        CROSS JOIN near_window
+        CROSS JOIN near_idf
+        WHERE near_idf.near_idf IS NOT NULL
+    ) AS scored
+    WHERE scored.tf > 0
+),
 selected_terms AS (
     SELECT query_term,
            termid,
@@ -593,6 +687,9 @@ field_term_tf AS (
     UNION ALL
     SELECT *
     FROM phrase_field_term_tf
+    UNION ALL
+    SELECT *
+    FROM near_field_term_tf
 ),
 {{field_scoring_score_ctes}},
 ranked AS (

--- a/src/sql/query/search_layered_bm25.sql
+++ b/src/sql/query/search_layered_bm25.sql
@@ -570,15 +570,35 @@ near_window AS (
     SELECT least(greatest(params.near_distance, 0), 4611686018427387903) + 1 AS width
     FROM params
 ),
+near_anchor AS (
+    SELECT termid
+    FROM near_slots
+    WHERE (SELECT count(*) FROM near_slots)
+        = (SELECT slot_count FROM near_slot_count)
+    ORDER BY df ASC,
+             slot ASC,
+             termid ASC
+    LIMIT 1
+),
+near_candidate_fields AS (
+    SELECT DISTINCT terms.docid,
+                    terms.fieldid
+    FROM near_anchor
+    JOIN {{fts_schema}}.terms AS terms
+      ON terms.termid = near_anchor.termid
+    WHERE terms.fieldid IN (SELECT fieldid FROM field_config)
+),
 near_grouped AS (
     SELECT terms.docid,
            terms.fieldid,
            list(terms.position::BIGINT) AS positions,
            list(near_slots.termid) AS termids
-    FROM near_slots
+    FROM near_candidate_fields AS candidates
     JOIN {{fts_schema}}.terms AS terms
-      ON terms.termid = near_slots.termid
-    WHERE terms.fieldid IN (SELECT fieldid FROM field_config)
+      ON terms.docid = candidates.docid
+     AND terms.fieldid = candidates.fieldid
+    JOIN near_slots
+      ON near_slots.termid = terms.termid
     GROUP BY terms.docid,
              terms.fieldid
 ),

--- a/src/sql/query/search_layered_bm25.sql
+++ b/src/sql/query/search_layered_bm25.sql
@@ -1,4 +1,4 @@
-CREATE MACRO {{fts_schema}}.__search_layered_bm25_non_pattern(query_string, fields := NULL, top_k := 50, k := 1.2, b := 0.75, term_limit := 32, max_df_ratio := 0.15, max_df := 50000, enable_prefix := true, enable_substring := true, enable_fuzzy := true, enable_short_fuzzy := true, expand_exact_terms := false, query_mode := 'standard', near_distance := 10, field_weights := NULL, field_b := NULL, scoring_model := 'bm25f', tie_breaker := 0.0) AS TABLE
+CREATE MACRO {{fts_schema}}.__search_layered_bm25_non_pattern(query_string, fields := NULL, top_k := 50, k := 1.2, b := 0.75, term_limit := 32, max_df_ratio := 0.15, max_df := 50000, enable_prefix := true, enable_substring := true, enable_fuzzy := true, enable_short_fuzzy := true, expand_exact_terms := false, query_mode := 'standard', field_weights := NULL, field_b := NULL, scoring_model := 'bm25f', tie_breaker := 0.0, near_distance := 10) AS TABLE
 WITH params(term_limit, max_df_ratio, max_df, enable_prefix, enable_substring, enable_fuzzy, enable_short_fuzzy, expand_exact_terms, query_mode, near_distance, field_weights, field_b, scoring_model, tie_breaker, default_b) AS (
     SELECT term_limit::BIGINT,
            max_df_ratio::DOUBLE,
@@ -18,7 +18,7 @@ WITH params(term_limit, max_df_ratio, max_df, enable_prefix, enable_substring, e
                WHEN 'regex' THEN 'regex'
                ELSE error('query_mode must be one of standard, autocomplete, phrase, phrase_prefix, near, wildcard, or regex')
            END,
-           near_distance::BIGINT,
+           try_cast(near_distance AS BIGINT),
            field_weights::MAP(VARCHAR, DOUBLE),
            field_b::MAP(VARCHAR, DOUBLE),
            lower(scoring_model::VARCHAR),
@@ -47,8 +47,13 @@ search_validation_errors AS (
         WHERE lower(coalesce(query_mode::VARCHAR, '')) = 'near'
           AND (
               near_distance IS NULL
-              OR try_cast(near_distance AS DOUBLE) IS NULL
-              OR try_cast(near_distance AS DOUBLE) < 0
+              OR try_cast(near_distance AS HUGEINT) IS NULL
+              OR try_cast(near_distance AS HUGEINT) < 0
+              OR try_cast(near_distance AS HUGEINT) > 9223372036854775807
+              -- Compared in the argument's own type: a DOUBLE round trip cannot
+              -- distinguish 2.0000000000000000001 from an exact 2. Strings hold
+              -- their fraction only through the DOUBLE comparison.
+              OR try_cast(near_distance AS HUGEINT) <> near_distance
               OR try_cast(near_distance AS DOUBLE)
                  <> floor(try_cast(near_distance AS DOUBLE))
           )

--- a/src/sql/query/search_layered_bm25.sql
+++ b/src/sql/query/search_layered_bm25.sql
@@ -102,7 +102,7 @@ query_shape AS (
                 AND count(*) = 1
                    THEN 'autocomplete'
                WHEN params.query_mode = 'near'
-                AND count(*) = 1
+                AND count(DISTINCT term) = 1
                    THEN 'standard'
                ELSE params.query_mode
            END AS effective_mode

--- a/src/sql/query/search_layered_bm25.sql
+++ b/src/sql/query/search_layered_bm25.sql
@@ -47,6 +47,7 @@ search_validation_errors AS (
         WHERE lower(coalesce(query_mode::VARCHAR, '')) = 'near'
           AND (
               near_distance IS NULL
+              OR typeof(near_distance) IN ('VARCHAR', 'BOOLEAN')
               OR try_cast(near_distance AS HUGEINT) IS NULL
               OR try_cast(near_distance AS HUGEINT) < 0
               OR try_cast(near_distance AS HUGEINT) > 9223372036854775807
@@ -715,10 +716,11 @@ results AS (
 SELECT *
 FROM results
 UNION ALL
--- In a filter, not the projection: a projected error() is dropped when docname is unused.
-SELECT NULL::VARCHAR AS docname,
-       NULL::DOUBLE AS score,
-       NULL::BIGINT AS rank
+-- Every column carries the error: a pushed predicate on a constant column
+-- would fold to false and drop this branch before its filter runs.
+SELECT CASE WHEN error(message) THEN NULL::VARCHAR END AS docname,
+       CASE WHEN error(message) THEN NULL::DOUBLE END AS score,
+       CASE WHEN error(message) THEN NULL::BIGINT END AS rank
 FROM search_validation_errors
 WHERE error(message)
 ORDER BY rank;

--- a/src/sql/query/search_layered_bm25_dispatch.sql
+++ b/src/sql/query/search_layered_bm25_dispatch.sql
@@ -1,4 +1,4 @@
-CREATE MACRO {{fts_schema}}.search_layered_bm25(query_string, fields := NULL, top_k := 50, k := 1.2, b := 0.75, term_limit := 32, max_df_ratio := 0.15, max_df := 50000, enable_prefix := true, enable_substring := true, enable_fuzzy := true, enable_short_fuzzy := true, expand_exact_terms := false, query_mode := 'standard', near_distance := 10, field_weights := NULL, field_b := NULL, scoring_model := 'bm25f', tie_breaker := 0.0) AS TABLE
+CREATE MACRO {{fts_schema}}.search_layered_bm25(query_string, fields := NULL, top_k := 50, k := 1.2, b := 0.75, term_limit := 32, max_df_ratio := 0.15, max_df := 50000, enable_prefix := true, enable_substring := true, enable_fuzzy := true, enable_short_fuzzy := true, expand_exact_terms := false, query_mode := 'standard', field_weights := NULL, field_b := NULL, scoring_model := 'bm25f', tie_breaker := 0.0, near_distance := 10) AS TABLE
 SELECT *
 FROM {{fts_schema}}.__search_layered_bm25_non_pattern(
     query_string,

--- a/src/sql/query/search_layered_bm25_dispatch.sql
+++ b/src/sql/query/search_layered_bm25_dispatch.sql
@@ -1,4 +1,4 @@
-CREATE MACRO {{fts_schema}}.search_layered_bm25(query_string, fields := NULL, top_k := 50, k := 1.2, b := 0.75, term_limit := 32, max_df_ratio := 0.15, max_df := 50000, enable_prefix := true, enable_substring := true, enable_fuzzy := true, enable_short_fuzzy := true, expand_exact_terms := false, query_mode := 'standard', field_weights := NULL, field_b := NULL, scoring_model := 'bm25f', tie_breaker := 0.0) AS TABLE
+CREATE MACRO {{fts_schema}}.search_layered_bm25(query_string, fields := NULL, top_k := 50, k := 1.2, b := 0.75, term_limit := 32, max_df_ratio := 0.15, max_df := 50000, enable_prefix := true, enable_substring := true, enable_fuzzy := true, enable_short_fuzzy := true, expand_exact_terms := false, query_mode := 'standard', near_distance := 10, field_weights := NULL, field_b := NULL, scoring_model := 'bm25f', tie_breaker := 0.0) AS TABLE
 SELECT *
 FROM {{fts_schema}}.__search_layered_bm25_non_pattern(
     query_string,
@@ -14,6 +14,7 @@ FROM {{fts_schema}}.__search_layered_bm25_non_pattern(
     enable_fuzzy := enable_fuzzy,
     enable_short_fuzzy := enable_short_fuzzy,
     expand_exact_terms := expand_exact_terms,
+    near_distance := near_distance,
     query_mode := query_mode,
     field_weights := field_weights,
     field_b := field_b,

--- a/src/sql/query/search_layered_bm25_query.sql
+++ b/src/sql/query/search_layered_bm25_query.sql
@@ -644,8 +644,12 @@ FROM ranked
 CROSS JOIN query_params
 WHERE query_params.result_limit IS NULL OR rank <= query_params.result_limit
 UNION ALL
-SELECT error(message)::VARCHAR AS docname,
-       NULL::DOUBLE AS score,
-       NULL::BIGINT AS rank
+-- Every column carries the error and the filter repeats it: a projected-only
+-- error is dropped when the column is unused, and a pushed predicate on a
+-- constant column would fold to false and drop the branch before it runs.
+SELECT CASE WHEN error(message) THEN NULL::VARCHAR END AS docname,
+       CASE WHEN error(message) THEN NULL::DOUBLE END AS score,
+       CASE WHEN error(message) THEN NULL::BIGINT END AS rank
 FROM selected_validation_error
+WHERE error(message)
 ORDER BY rank;

--- a/src/sql/query/search_layered_bm25_query.sql
+++ b/src/sql/query/search_layered_bm25_query.sql
@@ -109,7 +109,7 @@ leaves AS (
            CASE
                WHEN list_contains(json_keys(node_json), 'near_distance')
                    THEN coalesce(
-                       json_extract(node_json, '$.near_distance')::BIGINT,
+                       try_cast(json_extract(node_json, '$.near_distance') AS BIGINT),
                        10
                    )
                ELSE 10
@@ -191,10 +191,9 @@ raw_query_validation_errors AS (
     WHERE has_query
       AND list_contains(json_keys(node_json), 'near_distance')
       AND (
-          json_extract(node_json, '$.near_distance')::DOUBLE IS NULL
-          OR json_extract(node_json, '$.near_distance')::DOUBLE < 0
-          OR json_extract(node_json, '$.near_distance')::DOUBLE
-             <> floor(json_extract(node_json, '$.near_distance')::DOUBLE)
+          json_type(json_extract(node_json, '$.near_distance')) NOT IN ('UBIGINT', 'BIGINT')
+          OR try_cast(json_extract(node_json, '$.near_distance') AS BIGINT) IS NULL
+          OR try_cast(json_extract(node_json, '$.near_distance') AS BIGINT) < 0
       )
     UNION ALL
     SELECT 'query node contains duplicate keys' AS message

--- a/src/sql/query/search_layered_bm25_query.sql
+++ b/src/sql/query/search_layered_bm25_query.sql
@@ -106,6 +106,14 @@ leaves AS (
                    )
                ELSE 'standard'
            END AS query_mode,
+           CASE
+               WHEN list_contains(json_keys(node_json), 'near_distance')
+                   THEN coalesce(
+                       json_extract(node_json, '$.near_distance')::BIGINT,
+                       10
+                   )
+               ELSE 10
+           END AS near_distance,
            boost
     FROM node_config
     WHERE has_query
@@ -175,8 +183,19 @@ raw_query_validation_errors AS (
     UNION ALL
     SELECT 'query node contains unknown key: ' || node_key AS message
     FROM node_keys
-    WHERE (has_query AND NOT has_boolean AND node_key NOT IN ('query', 'fields', 'query_mode', 'boost'))
+    WHERE (has_query AND NOT has_boolean AND node_key NOT IN ('query', 'fields', 'query_mode', 'near_distance', 'boost'))
        OR (NOT has_query AND node_key NOT IN ('must', 'should', 'must_not', 'minimum_should_match', 'boost'))
+    UNION ALL
+    SELECT 'near_distance must be a non-negative integer' AS message
+    FROM query_nodes
+    WHERE has_query
+      AND list_contains(json_keys(node_json), 'near_distance')
+      AND (
+          json_extract(node_json, '$.near_distance')::DOUBLE IS NULL
+          OR json_extract(node_json, '$.near_distance')::DOUBLE < 0
+          OR json_extract(node_json, '$.near_distance')::DOUBLE
+             <> floor(json_extract(node_json, '$.near_distance')::DOUBLE)
+      )
     UNION ALL
     SELECT 'query node contains duplicate keys' AS message
     FROM query_nodes
@@ -214,7 +233,7 @@ raw_query_validation_errors AS (
     WHERE field_type = 'VARCHAR'
       AND field_name NOT IN (SELECT field FROM {{fts_schema}}.fields)
     UNION ALL
-    SELECT 'query_mode must be one of standard, autocomplete, phrase, phrase_prefix, wildcard, or regex' AS message
+    SELECT 'query_mode must be one of standard, autocomplete, phrase, phrase_prefix, near, wildcard, or regex' AS message
     FROM query_nodes
     WHERE has_query
       AND list_contains(json_keys(node_json), 'query_mode')
@@ -225,6 +244,7 @@ raw_query_validation_errors AS (
               'autocomplete',
               'phrase',
               'phrase_prefix',
+              'near',
               'wildcard',
               'regex'
           )
@@ -312,6 +332,7 @@ prepared_leaves AS (
            leaves.depth,
            leaves.query_string,
            leaves.query_mode,
+           leaves.near_distance,
            leaves.boost,
            field_lists.fields
     FROM leaves
@@ -498,6 +519,7 @@ non_pattern_leaf_scores AS (
         enable_short_fuzzy := query_params.use_short_fuzzy,
         expand_exact_terms := query_params.use_exact_expansion,
         query_mode := leaves.query_mode,
+        near_distance := leaves.near_distance,
         field_weights := query_params.scoring_weights,
         field_b := query_params.scoring_field_b,
         scoring_model := query_params.scoring_model,

--- a/src/sql/query/search_layered_pattern.sql
+++ b/src/sql/query/search_layered_pattern.sql
@@ -144,10 +144,11 @@ results AS (
 SELECT *
 FROM results
 UNION ALL
-SELECT NULL::VARCHAR AS docname,
-       NULL::DOUBLE AS score,
-       NULL::BIGINT AS rank
+-- Every column carries the error: a pushed predicate on a constant column
+-- would fold to false and drop this branch before its filter runs.
+SELECT CASE WHEN error(message) THEN NULL::VARCHAR END AS docname,
+       CASE WHEN error(message) THEN NULL::DOUBLE END AS score,
+       CASE WHEN error(message) THEN NULL::BIGINT END AS rank
 FROM search_validation_errors
--- In a filter, not the projection: a projected error() is dropped when docname is unused.
 WHERE error(message)
 ORDER BY rank;

--- a/test/sql/fts/test_boolean_query.test
+++ b/test/sql/fts/test_boolean_query.test
@@ -573,7 +573,7 @@ fields contains unknown field: missing
 statement error
 SELECT * FROM fts_main_boolean_docs.search_layered_bm25_query('{"query":"alpha","query_mode":"invalid"}'::JSON)
 ----
-query_mode must be one of standard, autocomplete, phrase, phrase_prefix, wildcard, or regex
+query_mode must be one of standard, autocomplete, phrase, phrase_prefix, near, wildcard, or regex
 
 statement error
 SELECT * FROM fts_main_boolean_docs.search_layered_bm25_query('{"query":"alpha","boost":-1}'::JSON)

--- a/test/sql/fts/test_field_scoring.test
+++ b/test/sql/fts/test_field_scoring.test
@@ -377,6 +377,11 @@ SELECT count(*) FROM fts_main_documents.search_layered_bm25('alpha', b := 5.0)
 b must be finite and between 0 and 1
 
 statement error
+SELECT * FROM fts_main_documents.search_layered_bm25('alpha', fields := 'missing') WHERE docname = 'doc1'
+----
+fields contains unknown field: missing
+
+statement error
 SELECT score FROM fts_main_documents.search_layered_bm25('alpha', fields := 'missing')
 ----
 fields contains unknown field: missing

--- a/test/sql/fts/test_near_search.test
+++ b/test/sql/fts/test_near_search.test
@@ -138,6 +138,77 @@ FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'n
 ----
 near_distance must be a non-negative integer
 
+# The error must also survive predicates pushed into the result.
+statement error
+SELECT fts_main_near_docs.match_layered_bm25(
+    'adjacent',
+    'machine learning',
+    query_mode := 'near',
+    near_distance := -1
+)
+----
+near_distance must be a non-negative integer
+
+statement error
+SELECT fts_main_near_docs.match_layered_bm25(
+    'missing',
+    'machine learning',
+    query_mode := 'near',
+    near_distance := -1
+)
+----
+near_distance must be a non-negative integer
+
+statement error
+SELECT *
+FROM fts_main_near_docs.search_layered_bm25(
+    'machine learning',
+    query_mode := 'near',
+    near_distance := -1
+)
+WHERE docname = 'adjacent'
+----
+near_distance must be a non-negative integer
+
+statement error
+SELECT *
+FROM fts_main_near_docs.search_layered_bm25_query('{"query": "machine learning", "query_mode": "near", "near_distance": -1}')
+WHERE docname = 'adjacent'
+----
+near_distance must be a non-negative integer
+
+statement error
+SELECT *
+FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := -1)
+WHERE score > 0
+----
+near_distance must be a non-negative integer
+
+statement error
+SELECT *
+FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := -1)
+WHERE rank <= 5
+----
+near_distance must be a non-negative integer
+
+statement error
+SELECT *
+FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := -1)
+LIMIT 1
+----
+near_distance must be a non-negative integer
+
+# The BIGINT contract rejects strings and booleans instead of coercing them.
+statement error
+SELECT * FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := '2.0000000000000000001')
+----
+near_distance must be a non-negative integer
+
+statement error
+SELECT * FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := true)
+----
+near_distance must be a non-negative integer
+
 statement error
 SELECT * FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 1.7)
 ----

--- a/test/sql/fts/test_near_search.test
+++ b/test/sql/fts/test_near_search.test
@@ -1,0 +1,355 @@
+# name: test/sql/fts/test_near_search.test
+# description: Proximity search — query terms within a bounded number of intervening tokens
+# group: [fts]
+
+require skip_reload
+
+require fts
+
+require json
+
+require no_alternative_verify
+
+statement ok
+CREATE TABLE near_docs(id VARCHAR NOT NULL, body VARCHAR)
+
+statement ok
+INSERT INTO near_docs VALUES
+    ('adjacent', 'machine learning is useful'),
+    ('gap2',     'machine assisted deep learning'),
+    ('gap6',     'machine one two three four five six learning'),
+    ('reversed', 'learning machine basics'),
+    ('only_one', 'machine intelligence'),
+    ('split',    'machine intelligence. learning theory')
+
+statement ok
+PRAGMA create_fts_index('near_docs', 'id', 'body', stemmer='none', stopwords='none', layered_search=true)
+
+query T
+SELECT list(docname ORDER BY docname)
+FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 0)
+----
+[adjacent, reversed]
+
+query T
+SELECT list(docname ORDER BY docname)
+FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 2)
+----
+[adjacent, gap2, reversed, split]
+
+query T
+SELECT list(docname ORDER BY docname)
+FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 10)
+----
+[adjacent, gap2, gap6, reversed, split]
+
+# The distance spans the whole match and counts the intervening query terms, so
+# three terms with two tokens between the outermost need near_distance 2, not 1.
+query T
+SELECT list(docname ORDER BY docname)
+FROM fts_main_near_docs.search_layered_bm25('machine deep learning', query_mode := 'near', near_distance := 2)
+----
+[gap2]
+
+query I
+SELECT count(*)
+FROM fts_main_near_docs.search_layered_bm25('machine deep learning', query_mode := 'near', near_distance := 1)
+----
+0
+
+query I
+SELECT count(*)
+FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 1000)
+WHERE docname = 'only_one'
+----
+0
+
+# Consecutive terms are not free: the term between the outermost two counts, so
+# three adjacent terms need near_distance 1 and only two need 0.
+query II
+SELECT
+    (SELECT count(*) FROM fts_main_near_docs.search_layered_bm25('machine assisted deep', query_mode := 'near', near_distance := 0)),
+    (SELECT count(*) FROM fts_main_near_docs.search_layered_bm25('machine assisted deep', query_mode := 'near', near_distance := 1))
+----
+0	1
+
+# Near mode matches exact dictionary terms, so a term in no document disqualifies
+# every document rather than dropping out and letting the rest match alone.
+query I
+SELECT count(*)
+FROM fts_main_near_docs.search_layered_bm25('machine absentword', query_mode := 'near', near_distance := 1000)
+----
+0
+
+query I
+SELECT count(*)
+FROM fts_main_near_docs.search_layered_bm25('machine learning absentword', query_mode := 'near', near_distance := 1000)
+----
+0
+
+query I
+SELECT count(*)
+FROM fts_main_near_docs.search_layered_bm25('machine lerning', query_mode := 'near', near_distance := 0)
+----
+0
+
+query I
+SELECT fts_main_near_docs.match_layered_bm25('adjacent', 'machine absentword', query_mode := 'near', near_distance := 1000) IS NULL
+----
+true
+
+statement error
+SELECT * FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', fields := 'missing')
+----
+fields contains unknown field: missing
+
+# Compared as a pair that both take the near path: a single-term query falls back
+# to standard mode and would not be a valid control here.
+query I
+SELECT abs(
+    (SELECT score FROM fts_main_near_docs.search_layered_bm25('machine machine learning', query_mode := 'near', near_distance := 10) WHERE docname = 'adjacent')
+  - (SELECT score FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 10) WHERE docname = 'adjacent')
+) < 1e-12
+----
+true
+
+statement error
+SELECT * FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := -1)
+----
+near_distance must be a non-negative integer
+
+statement error
+SELECT * FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 1.7)
+----
+near_distance must be a non-negative integer
+
+statement error
+SELECT * FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := NULL)
+----
+near_distance must be a non-negative integer
+
+# The span arithmetic adds one, so the maximum must saturate rather than overflow.
+query I
+SELECT count(*)
+FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 9223372036854775807)
+----
+5
+
+# Two thousand occurrences of each term, so work proportional to near_distance would time out.
+statement ok
+CREATE TABLE near_dense AS
+SELECT 'dense' AS id,
+       string_agg(CASE WHEN i % 2 = 0 THEN 'aster' ELSE 'brook' END, ' ') AS body
+FROM range(4000) t(i)
+
+statement ok
+PRAGMA create_fts_index('near_dense', 'id', 'body', stemmer='none', stopwords='none', layered_search=true)
+
+query I
+SELECT count(*)
+FROM fts_main_near_dense.search_layered_bm25('aster brook', query_mode := 'near', near_distance := 9223372036854775807)
+----
+1
+
+# Incremental maintenance reaches near results through the triggers.
+statement ok
+CREATE TABLE near_inc(id VARCHAR NOT NULL, body VARCHAR)
+
+statement ok
+INSERT INTO near_inc VALUES ('stale', 'machine learning basics')
+
+statement ok
+PRAGMA create_fts_index('near_inc', 'id', 'body', stemmer='none', stopwords='none', layered_search=true, incremental=true)
+
+statement ok
+INSERT INTO near_inc VALUES ('fresh', 'machine deep learning')
+
+statement ok
+DELETE FROM near_inc WHERE id = 'stale'
+
+query T
+SELECT list(docname ORDER BY docname)
+FROM fts_main_near_inc.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 1)
+----
+[fresh]
+
+# Clustered term storage returns the same matches.
+statement ok
+CREATE TABLE near_clu(id VARCHAR NOT NULL, body VARCHAR)
+
+statement ok
+INSERT INTO near_clu VALUES ('tight', 'machine learning basics'), ('gap1', 'machine x learning'), ('lone', 'machine only')
+
+statement ok
+PRAGMA create_fts_index('near_clu', 'id', 'body', stemmer='none', stopwords='none', layered_search=true, cluster_terms=true)
+
+query T
+SELECT list(docname ORDER BY docname)
+FROM fts_main_near_clu.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 1)
+----
+[gap1, tight]
+
+# term_limit caps expansions, which near mode does not use.
+query T
+SELECT list(docname ORDER BY docname)
+FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 0, term_limit := 1)
+----
+[adjacent, reversed]
+
+query TI
+SELECT id, fts_main_near_docs.match_layered_bm25(id, 'machine learning', query_mode := 'near', near_distance := 0) IS NOT NULL
+FROM near_docs ORDER BY id
+----
+adjacent	true
+gap2	false
+gap6	false
+only_one	false
+reversed	true
+split	false
+
+# A single token has no distance to constrain, so it behaves as an ordinary query.
+query I
+SELECT count(*)
+FROM fts_main_near_docs.search_layered_bm25('machine', query_mode := 'near', near_distance := 0)
+----
+6
+
+# Frequency follows the query term with the fewest matched occurrences, so two
+# documents differing only in which query term repeats score alike.
+statement ok
+CREATE TABLE near_frequency(id VARCHAR NOT NULL, body VARCHAR)
+
+statement ok
+INSERT INTO near_frequency VALUES
+    ('rare_twice',   'alpha alpha beta qqq'),
+    ('common_twice', 'alpha beta beta qqq'),
+    ('two_matches',   'alpha beta zzz alpha beta'),
+    ('one_match',    'alpha beta zzz zzz zzz'),
+    ('filler1',      'beta www'),
+    ('filler2',      'beta eee')
+
+statement ok
+PRAGMA create_fts_index('near_frequency', 'id', 'body', stemmer='none', stopwords='none', layered_search=true)
+
+query I
+SELECT (SELECT score FROM fts_main_near_frequency.search_layered_bm25('alpha beta', query_mode := 'near', near_distance := 1) WHERE docname = 'rare_twice')
+     = (SELECT score FROM fts_main_near_frequency.search_layered_bm25('alpha beta', query_mode := 'near', near_distance := 1) WHERE docname = 'common_twice')
+----
+true
+
+query I
+SELECT (SELECT score FROM fts_main_near_frequency.search_layered_bm25('alpha beta', query_mode := 'near', near_distance := 0) WHERE docname = 'two_matches')
+     > (SELECT score FROM fts_main_near_frequency.search_layered_bm25('alpha beta', query_mode := 'near', near_distance := 0) WHERE docname = 'one_match')
+----
+true
+
+# Quotation marks are tokenizer input, so a quoted query is the same set of terms
+# and still matches in either order.
+query I
+SELECT (SELECT list(docname ORDER BY docname) FROM fts_main_near_docs.search_layered_bm25('"machine learning"', query_mode := 'near', near_distance := 0))
+     = (SELECT list(docname ORDER BY docname) FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 0))
+----
+true
+
+# The default is FTS5's 10, so ten intervening tokens match and eleven do not.
+statement ok
+CREATE TABLE near_default(id VARCHAR NOT NULL, body VARCHAR)
+
+statement ok
+INSERT INTO near_default VALUES
+    ('gap10', 'a x x x x x x x x x x b'),
+    ('gap11', 'a x x x x x x x x x x x b')
+
+statement ok
+PRAGMA create_fts_index('near_default', 'id', 'body', stemmer='none', stopwords='none', layered_search=true)
+
+query TT
+SELECT (SELECT list(docname) FROM fts_main_near_default.search_layered_bm25('a b', query_mode := 'near')),
+       (SELECT list(docname ORDER BY docname) FROM fts_main_near_default.search_layered_bm25('a b', query_mode := 'near', near_distance := 11))
+----
+[gap10]	[gap10, gap11]
+
+# A match lies inside one indexed field and may not straddle two.
+statement ok
+CREATE TABLE near_fields(id VARCHAR NOT NULL, title VARCHAR, body VARCHAR)
+
+statement ok
+INSERT INTO near_fields VALUES ('split_fields', 'machine', 'learning'), ('one_field', 'zzz', 'machine learning')
+
+statement ok
+PRAGMA create_fts_index('near_fields', 'id', 'title', 'body', stemmer='none', stopwords='none', layered_search=true)
+
+query T
+SELECT list(docname ORDER BY docname)
+FROM fts_main_near_fields.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 1000)
+----
+[one_field]
+
+# The fields argument confines the match to the named field.
+query I
+SELECT count(*)
+FROM fts_main_near_fields.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 1000, fields := 'title')
+----
+0
+
+query T
+SELECT list(docname ORDER BY docname)
+FROM fts_main_near_fields.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 1000, fields := 'body')
+----
+[one_field]
+
+# Exact dictionary terms only, even with expansion switched on explicitly.
+query I
+SELECT count(*)
+FROM fts_main_near_docs.search_layered_bm25('machin learning', query_mode := 'near', near_distance := 1000, expand_exact_terms := true)
+----
+0
+
+# Query terms are matched after stemming, as in the other modes.
+statement ok
+CREATE TABLE near_stemmed(id VARCHAR NOT NULL, body VARCHAR)
+
+statement ok
+INSERT INTO near_stemmed VALUES ('stemmed', 'running machines here')
+
+statement ok
+PRAGMA create_fts_index('near_stemmed', 'id', 'body', stopwords='none', layered_search=true)
+
+query I
+SELECT count(*)
+FROM fts_main_near_stemmed.search_layered_bm25('run machine', query_mode := 'near', near_distance := 0)
+----
+1
+
+# The examples below are from the SQLite FTS5 documentation, on its own document
+# and with its own expected outcomes.
+statement ok
+CREATE TABLE fts5_docs(id VARCHAR NOT NULL, x VARCHAR)
+
+statement ok
+INSERT INTO fts5_docs VALUES ('1', 'A B C D x x x E F x')
+
+statement ok
+PRAGMA create_fts_index('fts5_docs', 'id', 'x', stemmer='none', stopwords='none', layered_search=true)
+
+# The query names the terms in the opposite order to the document, as FTS5 does.
+query III
+SELECT
+    (SELECT count(*) FROM fts_main_fts5_docs.search_layered_bm25('e d', query_mode := 'near', near_distance := 4)),
+    (SELECT count(*) FROM fts_main_fts5_docs.search_layered_bm25('e d', query_mode := 'near', near_distance := 3)),
+    (SELECT count(*) FROM fts_main_fts5_docs.search_layered_bm25('e d', query_mode := 'near', near_distance := 2))
+----
+1	1	0
+
+# Two terms are the identity case, so these three-term rows pin the definition.
+query II
+SELECT
+    (SELECT count(*) FROM fts_main_fts5_docs.search_layered_bm25('a d e', query_mode := 'near', near_distance := 6)),
+    (SELECT count(*) FROM fts_main_fts5_docs.search_layered_bm25('a d e', query_mode := 'near', near_distance := 5))
+----
+1	0
+
+statement error
+SELECT * FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'nearby')
+----
+query_mode must be one of standard, autocomplete, phrase, phrase_prefix, near, wildcard, or regex

--- a/test/sql/fts/test_near_search.test
+++ b/test/sql/fts/test_near_search.test
@@ -128,6 +128,16 @@ SELECT * FROM fts_main_near_docs.search_layered_bm25('machine learning', query_m
 ----
 near_distance must be a non-negative integer
 
+statement error
+SELECT * FROM fts_main_near_docs.search_layered_bm25_query('{"query": "machine learning", "query_mode": "near", "near_distance": -1}')
+----
+near_distance must be a non-negative integer
+
+statement error
+SELECT * FROM fts_main_near_docs.search_layered_bm25_query('{"query": "machine learning", "query_mode": "near", "near_distance": null}')
+----
+near_distance must be a non-negative integer
+
 # The span arithmetic adds one, so the maximum must saturate rather than overflow.
 query I
 SELECT count(*)
@@ -353,3 +363,108 @@ statement error
 SELECT * FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'nearby')
 ----
 query_mode must be one of standard, autocomplete, phrase, phrase_prefix, near, wildcard, or regex
+
+query I
+SELECT count(*)
+FROM fts_main_near_docs.search_layered_bm25_query('{"query": "machine absentword", "query_mode": "near", "near_distance": 1000}')
+----
+0
+
+# The structured surface takes near_distance per leaf.
+query T
+SELECT list(docname ORDER BY docname)
+FROM fts_main_near_docs.search_layered_bm25_query('{"query": "machine learning", "query_mode": "near", "near_distance": 0}')
+----
+[adjacent, reversed]
+
+query T
+SELECT list(docname ORDER BY docname)
+FROM fts_main_near_docs.search_layered_bm25_query('{"query": "machine learning", "query_mode": "near", "near_distance": 2}')
+----
+[adjacent, gap2, reversed, split]
+
+query T
+SELECT list(docname ORDER BY docname)
+FROM fts_main_near_docs.search_layered_bm25_query('{
+    "must": [{"query": "machine learning", "query_mode": "near", "near_distance": 10}],
+    "must_not": [{"query": "six"}]
+}')
+----
+[adjacent, gap2, reversed, split]
+
+query I
+SELECT (
+    SELECT count(*) FROM fts_main_near_docs.search_layered_bm25_query('{"query": "machine learning", "query_mode": "near"}')
+) = (
+    SELECT count(*) FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near')
+)
+----
+true
+
+statement error
+SELECT * FROM fts_main_near_docs.search_layered_bm25_query('{"query": "machine learning", "query_mode": "near", "slp": 2}')
+----
+unknown key
+
+# A near leaf composes with should, must_not, and a wildcard leaf.
+statement ok
+CREATE TABLE near_boolean(id VARCHAR NOT NULL, body VARCHAR)
+
+statement ok
+INSERT INTO near_boolean VALUES
+    ('both_clauses', 'machine learning with kiwi'),
+    ('near_only',    'machine learning plain'),
+    ('kiwi_only',    'kiwi standalone text'),
+    ('neither',      'unrelated words here')
+
+statement ok
+PRAGMA create_fts_index('near_boolean', 'id', 'body', stemmer='none', stopwords='none', layered_search=true)
+
+query T
+SELECT list(docname ORDER BY docname)
+FROM fts_main_near_boolean.search_layered_bm25_query('{
+    "should": [{"query": "machine learning", "query_mode": "near", "near_distance": 0}, {"query": "kiwi"}],
+    "minimum_should_match": 2
+}')
+----
+[both_clauses]
+
+query T
+SELECT list(docname ORDER BY docname)
+FROM fts_main_near_boolean.search_layered_bm25_query('{
+    "must": [{"query": "kiwi"}],
+    "must_not": [{"query": "machine learning", "query_mode": "near", "near_distance": 0}]
+}')
+----
+[kiwi_only]
+
+query T
+SELECT list(docname ORDER BY docname)
+FROM fts_main_near_boolean.search_layered_bm25_query('{
+    "must": [{"query": "machine learning", "query_mode": "near", "near_distance": 0}, {"query": "kiw*", "query_mode": "wildcard"}]
+}')
+----
+[both_clauses]
+
+# A single near leaf scores as the standalone near query, and boost scales it.
+query I
+SELECT (SELECT score FROM fts_main_near_boolean.search_layered_bm25_query('{"query": "machine learning", "query_mode": "near", "near_distance": 0}') WHERE docname = 'near_only')
+     = (SELECT score FROM fts_main_near_boolean.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 0) WHERE docname = 'near_only')
+----
+true
+
+query I
+SELECT (SELECT score FROM fts_main_near_boolean.search_layered_bm25_query('{"query": "machine learning", "query_mode": "near", "near_distance": 0, "boost": 2.0}') WHERE docname = 'near_only')
+     = 2 * (SELECT score FROM fts_main_near_boolean.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 0) WHERE docname = 'near_only')
+----
+true
+
+# Under should, a near leaf and a standard leaf contribute their own scores.
+query I
+SELECT abs((SELECT score FROM fts_main_near_boolean.search_layered_bm25_query('{
+        "should": [{"query": "machine learning", "query_mode": "near", "near_distance": 0}, {"query": "kiwi"}]
+    }') WHERE docname = 'both_clauses')
+    - ((SELECT score FROM fts_main_near_boolean.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 0) WHERE docname = 'both_clauses')
+     + (SELECT score FROM fts_main_near_boolean.search_layered_bm25('kiwi') WHERE docname = 'both_clauses'))) < 1e-12
+----
+true

--- a/test/sql/fts/test_near_search.test
+++ b/test/sql/fts/test_near_search.test
@@ -600,3 +600,25 @@ SELECT abs((SELECT score FROM fts_main_near_boolean.search_layered_bm25_query('{
      + (SELECT score FROM fts_main_near_boolean.search_layered_bm25('kiwi') WHERE docname = 'both_clauses'))) < 1e-12
 ----
 true
+
+# A single query term repeated must still fall back to standard mode: repeated
+# terms count once, so the fallback is gated on distinct terms, not raw token
+# positions (lnkuiper, #56).
+statement ok
+CREATE TABLE near_single_term(id VARCHAR NOT NULL, body VARCHAR)
+
+statement ok
+INSERT INTO near_single_term VALUES ('a', 'machine')
+
+statement ok
+PRAGMA create_fts_index('near_single_term', 'id', 'body', stemmer='none', stopwords='none', layered_search=true)
+
+query I
+SELECT count(*) FROM fts_main_near_single_term.search_layered_bm25('machin', query_mode := 'near', near_distance := 0)
+----
+1
+
+query I
+SELECT count(*) FROM fts_main_near_single_term.search_layered_bm25('machin machin', query_mode := 'near', near_distance := 0)
+----
+1

--- a/test/sql/fts/test_near_search.test
+++ b/test/sql/fts/test_near_search.test
@@ -118,6 +118,26 @@ SELECT * FROM fts_main_near_docs.search_layered_bm25('machine learning', query_m
 ----
 near_distance must be a non-negative integer
 
+# The error must fire regardless of which columns the caller projects.
+statement error
+SELECT count(*)
+FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := -1)
+----
+near_distance must be a non-negative integer
+
+statement error
+SELECT EXISTS (
+    FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := -1)
+)
+----
+near_distance must be a non-negative integer
+
+statement error
+SELECT score
+FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := -1)
+----
+near_distance must be a non-negative integer
+
 statement error
 SELECT * FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 1.7)
 ----

--- a/test/sql/fts/test_near_search.test
+++ b/test/sql/fts/test_near_search.test
@@ -622,3 +622,23 @@ query I
 SELECT count(*) FROM fts_main_near_single_term.search_layered_bm25('machin machin', query_mode := 'near', near_distance := 0)
 ----
 1
+
+# The candidate-field restriction introduced for anchor-term pruning must key on
+# (docid, fieldid): a rare and a common term in DIFFERENT fields of the same
+# document must not match, only the same-field co-occurrence should (lnkuiper, #56).
+statement ok
+CREATE TABLE near_anchor_fields(id VARCHAR NOT NULL, title VARCHAR, body VARCHAR)
+
+statement ok
+INSERT INTO near_anchor_fields VALUES
+    ('cross_field', 'rareword', 'common text here'),
+    ('same_field',  'unrelated', 'rareword common text here')
+
+statement ok
+PRAGMA create_fts_index('near_anchor_fields', 'id', 'title', 'body', stemmer='none', stopwords='none', layered_search=true)
+
+query I
+SELECT list(docname ORDER BY docname)
+FROM fts_main_near_anchor_fields.search_layered_bm25('rareword common', query_mode := 'near', near_distance := 5)
+----
+[same_field]

--- a/test/sql/fts/test_near_search.test
+++ b/test/sql/fts/test_near_search.test
@@ -138,6 +138,47 @@ SELECT * FROM fts_main_near_docs.search_layered_bm25_query('{"query": "machine l
 ----
 near_distance must be a non-negative integer
 
+# Structured near_distance requires an integer JSON number, like boost.
+statement error
+SELECT * FROM fts_main_near_docs.search_layered_bm25_query('{"query": "machine learning", "query_mode": "near", "near_distance": "2"}')
+----
+near_distance must be a non-negative integer
+
+statement error
+SELECT * FROM fts_main_near_docs.search_layered_bm25_query('{"query": "machine learning", "query_mode": "near", "near_distance": true}')
+----
+near_distance must be a non-negative integer
+
+statement error
+SELECT * FROM fts_main_near_docs.search_layered_bm25_query('{"query": "machine learning", "query_mode": "near", "near_distance": "x"}')
+----
+near_distance must be a non-negative integer
+
+# The integer check keeps the argument's own precision and the BIGINT range.
+statement error
+SELECT * FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 2.0000000000000000001)
+----
+near_distance must be a non-negative integer
+
+statement error
+SELECT * FROM fts_main_near_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 9223372036854775808)
+----
+near_distance must be a non-negative integer
+
+# Positional calls from before near mode stay valid: near_distance is appended last.
+query T
+SELECT list(docname ORDER BY docname)
+FROM fts_main_near_docs.search_layered_bm25('machine', NULL, 50, 1.2, 0.75, 32, 0.15, 50000, true, true, true, true, false, 'standard', MAP {'body': 2.0}, NULL, 'bm25f', 0.0)
+----
+[adjacent, gap2, gap6, only_one, reversed, split]
+
+query I
+SELECT count(*)
+FROM near_docs
+WHERE fts_main_near_docs.match_layered_bm25(id, 'machine', NULL, 1.2, 0.75, 32, 0.15, 50000, true, true, true, true, false, 'standard', MAP {'body': 2.0}, NULL, 'bm25f', 0.0) IS NOT NULL
+----
+6
+
 # The span arithmetic adds one, so the maximum must saturate rather than overflow.
 query I
 SELECT count(*)

--- a/test/sql/fts/test_pattern_persistence.test
+++ b/test/sql/fts/test_pattern_persistence.test
@@ -49,6 +49,17 @@ FROM fts_main_documents.search_layered_bm25(
 ----
 d1
 
+# A persisted near query binds fts_near_tf through the same autoload.
+query I
+SELECT count(*)
+FROM fts_main_documents.search_layered_bm25(
+    'database catalog',
+    query_mode := 'near',
+    near_distance := 0
+)
+----
+0
+
 restart no_extension_load
 
 statement ok

--- a/test/sql/fts/test_pattern_search.test
+++ b/test/sql/fts/test_pattern_search.test
@@ -495,7 +495,7 @@ FROM fts_main_pattern_docs.search_layered_bm25_query(
     '{"query":"data*","query_mode":"unsupported"}'::JSON
 )
 ----
-query_mode must be one of standard, autocomplete, phrase, phrase_prefix, wildcard, or regex
+query_mode must be one of standard, autocomplete, phrase, phrase_prefix, near, wildcard, or regex
 
 statement error
 FROM fts_main_pattern_docs.search_layered_bm25_query(


### PR DESCRIPTION
Layered FTS matches exact phrases and unordered terms, but nothing in between. Issue #17 asks for proximity search in FTS5's spelling, NEAR(machine learning, 5), and it is the last item on that list still open.

I added a `near` query mode with a `near_distance` parameter to the table, scalar and structured Boolean search macros, reusing the positional postings phrase mode already maintains, so the index format does not change. The bound is SQLite FTS5's NEAR N rather than Lucene's slop, and the README states the rule. Near mode joins the exact term dictionary, so expansion does not apply and a misspelling matches nothing.

`near_distance` is validated rather than coerced, and the validations hold regardless of which columns the caller reads or filters. Near matches are found by a small C++ scan over each document's positional postings, so query time does not depend on `near_distance`: the local 50K cases run in approximately 45-150 ms, and a dense document at the maximum distance answers in under 0.2 seconds. Match frequency follows the query term with the fewest matched occurrences, so a term repeated on its own does not raise the score.

I added coverage for FTS5's documented examples, order independence, repeated and absent terms, stopword gaps, single-term queries, each invalid `near_distance`, and agreement between the three surfaces. The near benchmarks mirror the phrase set, plus a dense document at the maximum distance.

