### PR TITLE
Compile FTS5 query strings to structured layered queries

### DIFF
--- a/.github/regression/fts_parser.csv
+++ b/.github/regression/fts_parser.csv
@@ -1,0 +1,4 @@
+benchmark/fts/layered_autocomplete/smoke/parse_terms.benchmark
+benchmark/fts/layered_autocomplete/smoke/parse_boolean.benchmark
+benchmark/fts/layered_autocomplete/smoke/parse_phrase.benchmark
+benchmark/fts/layered_autocomplete/smoke/parse_near.benchmark

--- a/.github/regression/fts_parser_haystack.csv
+++ b/.github/regression/fts_parser_haystack.csv
@@ -1,0 +1,4 @@
+benchmark/fts/layered_autocomplete/haystack/parse_terms.benchmark
+benchmark/fts/layered_autocomplete/haystack/parse_boolean.benchmark
+benchmark/fts/layered_autocomplete/haystack/parse_phrase.benchmark
+benchmark/fts/layered_autocomplete/haystack/parse_near.benchmark

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -145,6 +145,7 @@ jobs:
               echo "ANALYZER_BENCHMARKS=.github/regression/fts_analyzer_haystack.csv"
               echo "PATTERN_BENCHMARKS=.github/regression/fts_pattern_haystack.csv"
               echo "NEAR_BENCHMARKS=.github/regression/fts_near_haystack.csv"
+              echo "PARSER_BENCHMARKS=.github/regression/fts_parser_haystack.csv"
               echo "FOOTPRINT_ROWS=1000000"
               echo "BENCHMARK_BUDGET_SECONDS=3600"
             } >> "$GITHUB_ENV"
@@ -158,6 +159,7 @@ jobs:
               echo "ANALYZER_BENCHMARKS=.github/regression/fts_analyzer.csv"
               echo "PATTERN_BENCHMARKS=.github/regression/fts_pattern.csv"
               echo "NEAR_BENCHMARKS=.github/regression/fts_near.csv"
+              echo "PARSER_BENCHMARKS=.github/regression/fts_parser.csv"
               echo "FOOTPRINT_ROWS=50000"
               echo "BENCHMARK_BUDGET_SECONDS=600"
             } >> "$GITHUB_ENV"
@@ -248,10 +250,20 @@ jobs:
               --clear-benchmark-cache \
               --nofail \
               --verbose 2>&1 | tee near-smoke.log
+
+            python3 duckdb/scripts/regression/test_runner.py \
+              --old "$NEW_RUNNER" \
+              --new "$NEW_RUNNER" \
+              --benchmarks "$PARSER_BENCHMARKS" \
+              --root-dir . \
+              --threads 2 \
+              --clear-benchmark-cache \
+              --nofail \
+              --verbose 2>&1 | tee parser-smoke.log
           }
 
           export -f run_benchmarks
-          export OLD_RUNNER NEW_RUNNER LAYERED_BENCHMARKS AUTOCOMPLETE_BENCHMARKS FIELD_SCORING_BENCHMARKS BOOLEAN_BENCHMARKS PHRASE_BENCHMARKS ANALYZER_BENCHMARKS PATTERN_BENCHMARKS NEAR_BENCHMARKS
+          export OLD_RUNNER NEW_RUNNER LAYERED_BENCHMARKS AUTOCOMPLETE_BENCHMARKS FIELD_SCORING_BENCHMARKS BOOLEAN_BENCHMARKS PHRASE_BENCHMARKS ANALYZER_BENCHMARKS PATTERN_BENCHMARKS NEAR_BENCHMARKS PARSER_BENCHMARKS
           timeout "${BENCHMARK_BUDGET_SECONDS}s" bash -c run_benchmarks
 
       - name: Report positional index footprint
@@ -299,6 +311,10 @@ jobs:
             echo '```text'
             test ! -f near-smoke.log || cat near-smoke.log
             echo '```'
+            echo '## FTS query parser smoke'
+            echo '```text'
+            test ! -f parser-smoke.log || cat parser-smoke.log
+            echo '```'
             echo '## FTS positional index footprint'
             echo '```text'
             test ! -f phrase-footprint.log || cat phrase-footprint.log
@@ -319,5 +335,6 @@ jobs:
             analyzer-smoke.log
             pattern-smoke.log
             near-smoke.log
+            parser-smoke.log
             phrase-footprint.log
           if-no-files-found: ignore

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ set(EXTENSION_SOURCES
     ${EXTENSION_BASE_FOLDER}/fts_indexing.cpp
     ${EXTENSION_BASE_FOLDER}/fts_near.cpp
     ${EXTENSION_BASE_FOLDER}/fts_pattern.cpp
+    ${EXTENSION_BASE_FOLDER}/fts_query_parser.cpp
     ${EXTENSION_BASE_FOLDER}/fts_sql_template.cpp
     ${EXTENSION_BASE_FOLDER}/fts_unicode_classifier.cpp
     ${FTS_SQL_ASSETS_SOURCE}

--- a/README.md
+++ b/README.md
@@ -377,6 +377,38 @@ out-of-range `minimum_should_match` values are rejected. Setting
 `minimum_should_match` explicitly to zero on a should-only group matches all
 indexed documents; documents that match no optional leaf receive score `0`.
 
+### `fts_parse_query` Function
+
+```python
+fts_parse_query(query_string)
+```
+
+Compiles an SQLite FTS5 query string into the JSON tree that
+`search_layered_bm25_query` and `match_layered_bm25_query` execute. The result
+is a struct with `query_json` and `error_message`; exactly one of them is
+`NULL`. Supported FTS5 syntax: implicit and explicit `AND`, `OR`, binary
+`NOT`, parentheses, `"quoted phrases"` with `""` escaping and `+`
+concatenation, trailing `*` prefixes, `col :` and `{col1 col2} :` column
+filters, and `NEAR(term1 term2 ..., N)`. Keywords are recognized in capital
+letters only, exactly as in FTS5.
+
+```sql
+SELECT fts_parse_query('author : han OR "quacking quac" *').query_json;
+-- {"should":[{"query":"han","fields":["author"]},{"query":"quacking quac","query_mode":"phrase_prefix"}]}
+
+SELECT docname, score, rank
+FROM fts_main_animal_sounds.search_layered_bm25_query(
+    fts_parse_query('quack NOT archive').query_json::JSON,
+    top_k := 10
+);
+```
+
+The parser is a pure function: field names are checked by the structured
+macros at query time, `NEAR` distances map to `near_distance` one to one, and
+nesting is bounded at depth 256 like FTS5's own parser. Initial-token anchors
+(`^`), column complements (`-col :`), and phrases inside `NEAR` are not
+supported and are rejected with named errors.
+
 ### `stem` Function
 
 ```python
@@ -607,6 +639,17 @@ FROM fts_main_animal_sounds.search_layered_bm25(
     'quacking quac',
     fields := 'text_content',
     query_mode := 'phrase_prefix',
+    top_k := 10
+);
+```
+
+The same searches can be written as FTS5 query strings and compiled with
+`fts_parse_query`:
+
+```sql
+SELECT docname, score, rank
+FROM fts_main_animal_sounds.search_layered_bm25_query(
+    fts_parse_query('"quacking quac" * OR author : mark').query_json::JSON,
     top_k := 10
 );
 ```

--- a/benchmark/fts/layered_autocomplete/haystack/parse_boolean.benchmark
+++ b/benchmark/fts/layered_autocomplete/haystack/parse_boolean.benchmark
@@ -1,0 +1,4 @@
+template benchmark/fts/layered_autocomplete/templates/parse_query.benchmark.in
+display_name=FTS Boolean query parsing (1M)
+rows=1000000
+query_expr='(alpha' || (i % 50)::VARCHAR || ' OR beta' || (i % 20)::VARCHAR || ') NOT gamma' || (i % 10)::VARCHAR

--- a/benchmark/fts/layered_autocomplete/haystack/parse_near.benchmark
+++ b/benchmark/fts/layered_autocomplete/haystack/parse_near.benchmark
@@ -1,0 +1,4 @@
+template benchmark/fts/layered_autocomplete/templates/parse_query.benchmark.in
+display_name=FTS near query parsing (1M)
+rows=1000000
+query_expr='NEAR(workspace item' || (i % 100)::VARCHAR || ' search' || (i % 20)::VARCHAR || ', ' || (i % 30)::VARCHAR || ')'

--- a/benchmark/fts/layered_autocomplete/haystack/parse_phrase.benchmark
+++ b/benchmark/fts/layered_autocomplete/haystack/parse_phrase.benchmark
@@ -1,0 +1,4 @@
+template benchmark/fts/layered_autocomplete/templates/parse_query.benchmark.in
+display_name=FTS phrase query parsing (1M)
+rows=1000000
+query_expr='title : "workspace item' || (i % 100)::VARCHAR || '" + search' || (i % 20)::VARCHAR || '*'

--- a/benchmark/fts/layered_autocomplete/haystack/parse_terms.benchmark
+++ b/benchmark/fts/layered_autocomplete/haystack/parse_terms.benchmark
@@ -1,0 +1,4 @@
+template benchmark/fts/layered_autocomplete/templates/parse_query.benchmark.in
+display_name=FTS bare-term query parsing (1M)
+rows=1000000
+query_expr='workspace item' || (i % 100)::VARCHAR || ' search benchmark' || (i % 20)::VARCHAR

--- a/benchmark/fts/layered_autocomplete/smoke/parse_boolean.benchmark
+++ b/benchmark/fts/layered_autocomplete/smoke/parse_boolean.benchmark
@@ -1,0 +1,4 @@
+template benchmark/fts/layered_autocomplete/templates/parse_query.benchmark.in
+display_name=FTS Boolean query parsing (50K)
+rows=50000
+query_expr='(alpha' || (i % 50)::VARCHAR || ' OR beta' || (i % 20)::VARCHAR || ') NOT gamma' || (i % 10)::VARCHAR

--- a/benchmark/fts/layered_autocomplete/smoke/parse_near.benchmark
+++ b/benchmark/fts/layered_autocomplete/smoke/parse_near.benchmark
@@ -1,0 +1,4 @@
+template benchmark/fts/layered_autocomplete/templates/parse_query.benchmark.in
+display_name=FTS near query parsing (50K)
+rows=50000
+query_expr='NEAR(workspace item' || (i % 100)::VARCHAR || ' search' || (i % 20)::VARCHAR || ', ' || (i % 30)::VARCHAR || ')'

--- a/benchmark/fts/layered_autocomplete/smoke/parse_phrase.benchmark
+++ b/benchmark/fts/layered_autocomplete/smoke/parse_phrase.benchmark
@@ -1,0 +1,4 @@
+template benchmark/fts/layered_autocomplete/templates/parse_query.benchmark.in
+display_name=FTS phrase query parsing (50K)
+rows=50000
+query_expr='title : "workspace item' || (i % 100)::VARCHAR || '" + search' || (i % 20)::VARCHAR || '*'

--- a/benchmark/fts/layered_autocomplete/smoke/parse_terms.benchmark
+++ b/benchmark/fts/layered_autocomplete/smoke/parse_terms.benchmark
@@ -1,0 +1,4 @@
+template benchmark/fts/layered_autocomplete/templates/parse_query.benchmark.in
+display_name=FTS bare-term query parsing (50K)
+rows=50000
+query_expr='workspace item' || (i % 100)::VARCHAR || ' search benchmark' || (i % 20)::VARCHAR

--- a/benchmark/fts/layered_autocomplete/templates/parse_query.benchmark.in
+++ b/benchmark/fts/layered_autocomplete/templates/parse_query.benchmark.in
@@ -1,0 +1,26 @@
+name ${display_name}
+group fts
+subgroup parser
+
+require fts
+
+init
+CREATE TABLE queries(q VARCHAR NOT NULL);
+INSERT INTO queries
+SELECT ${query_expr}
+FROM range(${rows}) AS source(i);
+
+load
+SELECT count((fts_parse_query(q)).query_json) FROM queries;
+
+assert II
+SELECT count(*) = ${rows},
+       count(p.error_message) = 0
+FROM (SELECT fts_parse_query(q) AS p FROM queries) AS parsed
+----
+true	true
+
+run
+SELECT count(p.query_json),
+       sum(length(p.query_json))
+FROM (SELECT fts_parse_query(q) AS p FROM queries) AS parsed;

--- a/src/fts_extension.cpp
+++ b/src/fts_extension.cpp
@@ -13,6 +13,7 @@
 #include "fts_indexing.hpp"
 #include "fts_near.hpp"
 #include "fts_pattern.hpp"
+#include "fts_query_parser.hpp"
 #include "fts_unicode_classifier.hpp"
 #include "libstemmer.h"
 #include "utf8proc_wrapper.hpp"
@@ -236,6 +237,7 @@ static void LoadInternal(ExtensionLoader &loader) {
   loader.RegisterFunction(opensearch_standard_tokenize_func);
   loader.RegisterFunction(GetFTSAnalyzePatternFunction());
   loader.RegisterFunction(GetFTSNearTfFunction());
+  loader.RegisterFunction(GetFTSParseQueryFunction());
   loader.RegisterFunction(create_fts_index_func);
   loader.RegisterFunction(create_fts_boolean_query_macros_func);
   loader.RegisterFunction(drop_fts_index_func);

--- a/src/fts_query_parser.cpp
+++ b/src/fts_query_parser.cpp
@@ -1,0 +1,664 @@
+#include "fts_query_parser.hpp"
+
+#include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/common/vector/vector_writer.hpp"
+
+namespace duckdb {
+
+namespace {
+
+enum class QueryTokenType : uint8_t {
+  BAREWORD,
+  STRING,
+  KEYWORD_AND,
+  KEYWORD_OR,
+  KEYWORD_NOT,
+  STAR,
+  PLUS,
+  COMMA,
+  COLON,
+  MINUS,
+  CARET,
+  LPAREN,
+  RPAREN,
+  LBRACE,
+  RBRACE,
+  END
+};
+
+struct QueryToken {
+  QueryTokenType type;
+  string text;
+};
+
+// FTS5 barewords admit ASCII alphanumerics, '_', U+001A and any non-ASCII byte.
+static bool IsBarewordByte(char c) {
+  auto b = static_cast<unsigned char>(c);
+  return (b >= '0' && b <= '9') || (b >= 'A' && b <= 'Z') ||
+         (b >= 'a' && b <= 'z') || b == '_' || b == 0x1A || b >= 0x80;
+}
+
+static string Lex(const string &input, vector<QueryToken> &tokens) {
+  idx_t position = 0;
+  while (position < input.size()) {
+    auto c = input[position];
+    if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+      position++;
+      continue;
+    }
+    if (c == '"') {
+      string text;
+      position++;
+      auto closed = false;
+      while (position < input.size()) {
+        if (input[position] == '"') {
+          if (position + 1 < input.size() && input[position + 1] == '"') {
+            text += '"';
+            position += 2;
+            continue;
+          }
+          position++;
+          closed = true;
+          break;
+        }
+        text += input[position];
+        position++;
+      }
+      if (!closed) {
+        return "fts5 query contains an unclosed string";
+      }
+      tokens.push_back({QueryTokenType::STRING, text});
+      continue;
+    }
+    if (IsBarewordByte(c)) {
+      string text;
+      while (position < input.size() && IsBarewordByte(input[position])) {
+        text += input[position];
+        position++;
+      }
+      auto type = QueryTokenType::BAREWORD;
+      if (text == "AND") {
+        type = QueryTokenType::KEYWORD_AND;
+      } else if (text == "OR") {
+        type = QueryTokenType::KEYWORD_OR;
+      } else if (text == "NOT") {
+        type = QueryTokenType::KEYWORD_NOT;
+      }
+      tokens.push_back({type, text});
+      continue;
+    }
+    switch (c) {
+    case '*':
+      tokens.push_back({QueryTokenType::STAR, "*"});
+      break;
+    case '+':
+      tokens.push_back({QueryTokenType::PLUS, "+"});
+      break;
+    case ',':
+      tokens.push_back({QueryTokenType::COMMA, ","});
+      break;
+    case ':':
+      tokens.push_back({QueryTokenType::COLON, ":"});
+      break;
+    case '-':
+      tokens.push_back({QueryTokenType::MINUS, "-"});
+      break;
+    case '^':
+      tokens.push_back({QueryTokenType::CARET, "^"});
+      break;
+    case '(':
+      tokens.push_back({QueryTokenType::LPAREN, "("});
+      break;
+    case ')':
+      tokens.push_back({QueryTokenType::RPAREN, ")"});
+      break;
+    case '{':
+      tokens.push_back({QueryTokenType::LBRACE, "{"});
+      break;
+    case '}':
+      tokens.push_back({QueryTokenType::RBRACE, "}"});
+      break;
+    default:
+      return "fts5 query contains a character that requires quoting";
+    }
+    position++;
+  }
+  tokens.push_back({QueryTokenType::END, ""});
+  return string();
+}
+
+// FTS5 itself bounds nesting (its error names a maximum depth of 256); the
+// same bound keeps the recursive descent and the serializer within the stack.
+static constexpr idx_t MAX_QUERY_DEPTH = 256;
+
+enum class QueryNodeType : uint8_t { LEAF, GROUP_AND, GROUP_OR, GROUP_NOT };
+
+struct QueryNode {
+  QueryNodeType type = QueryNodeType::LEAF;
+  string query;
+  string query_mode;
+  string near_distance;
+  vector<string> fields;
+  bool grouped = false;
+  vector<unique_ptr<QueryNode>> children;
+};
+
+static string EscapeJSON(const string &input) {
+  string result;
+  for (auto c : input) {
+    switch (c) {
+    case '"':
+      result += "\\\"";
+      break;
+    case '\\':
+      result += "\\\\";
+      break;
+    case '\n':
+      result += "\\n";
+      break;
+    case '\r':
+      result += "\\r";
+      break;
+    case '\t':
+      result += "\\t";
+      break;
+    default:
+      if (static_cast<unsigned char>(c) < 0x20) {
+        result += StringUtil::Format("\\u%04x", c);
+      } else {
+        result += c;
+      }
+    }
+  }
+  return result;
+}
+
+struct QueryParser {
+  const vector<QueryToken> &tokens;
+  idx_t position = 0;
+  idx_t depth = 0;
+  string error;
+
+  explicit QueryParser(const vector<QueryToken> &tokens) : tokens(tokens) {}
+
+  const QueryToken &Peek(idx_t offset = 0) const {
+    auto index = MinValue<idx_t>(position + offset, tokens.size() - 1);
+    return tokens[index];
+  }
+
+  const QueryToken &Next() {
+    auto &token = tokens[position];
+    if (position + 1 < tokens.size()) {
+      position++;
+    }
+    return token;
+  }
+
+  bool StartsPrimary(const QueryToken &token) const {
+    switch (token.type) {
+    case QueryTokenType::BAREWORD:
+    case QueryTokenType::STRING:
+    case QueryTokenType::LBRACE:
+    case QueryTokenType::MINUS:
+    case QueryTokenType::CARET:
+    case QueryTokenType::LPAREN:
+      return true;
+    default:
+      return false;
+    }
+  }
+
+  unique_ptr<QueryNode> ParseOr(const vector<string> &fields);
+  unique_ptr<QueryNode> ParseAnd(const vector<string> &fields);
+  unique_ptr<QueryNode> ParseNot(const vector<string> &fields);
+  unique_ptr<QueryNode> ParseImplicit(const vector<string> &fields);
+  unique_ptr<QueryNode> ParsePrimary(const vector<string> &fields);
+  unique_ptr<QueryNode> ParseNear(const vector<string> &fields);
+  unique_ptr<QueryNode> ParsePhrase(const vector<string> &fields);
+};
+
+unique_ptr<QueryNode> QueryParser::ParseOr(const vector<string> &fields) {
+  auto left = ParseAnd(fields);
+  if (!left) {
+    return nullptr;
+  }
+  while (Peek().type == QueryTokenType::KEYWORD_OR) {
+    Next();
+    auto right = ParseAnd(fields);
+    if (!right) {
+      return nullptr;
+    }
+    if (left->type == QueryNodeType::GROUP_OR && !left->grouped) {
+      left->children.push_back(std::move(right));
+    } else {
+      auto group = make_uniq<QueryNode>();
+      group->type = QueryNodeType::GROUP_OR;
+      group->children.push_back(std::move(left));
+      group->children.push_back(std::move(right));
+      left = std::move(group);
+    }
+  }
+  return left;
+}
+
+unique_ptr<QueryNode> QueryParser::ParseAnd(const vector<string> &fields) {
+  auto left = ParseNot(fields);
+  if (!left) {
+    return nullptr;
+  }
+  while (Peek().type == QueryTokenType::KEYWORD_AND) {
+    Next();
+    auto right = ParseNot(fields);
+    if (!right) {
+      return nullptr;
+    }
+    if (left->type == QueryNodeType::GROUP_AND && !left->grouped) {
+      left->children.push_back(std::move(right));
+    } else {
+      auto group = make_uniq<QueryNode>();
+      group->type = QueryNodeType::GROUP_AND;
+      group->children.push_back(std::move(left));
+      group->children.push_back(std::move(right));
+      left = std::move(group);
+    }
+  }
+  return left;
+}
+
+unique_ptr<QueryNode> QueryParser::ParseNot(const vector<string> &fields) {
+  auto left = ParseImplicit(fields);
+  if (!left) {
+    return nullptr;
+  }
+  while (Peek().type == QueryTokenType::KEYWORD_NOT) {
+    // NOT chains deepen the final tree permanently, so this is not refunded.
+    if (++depth > MAX_QUERY_DEPTH) {
+      error = "fts5 query is nested too deeply";
+      return nullptr;
+    }
+    Next();
+    auto right = ParseImplicit(fields);
+    if (!right) {
+      return nullptr;
+    }
+    auto group = make_uniq<QueryNode>();
+    group->type = QueryNodeType::GROUP_NOT;
+    group->children.push_back(std::move(left));
+    group->children.push_back(std::move(right));
+    left = std::move(group);
+  }
+  return left;
+}
+
+unique_ptr<QueryNode> QueryParser::ParseImplicit(const vector<string> &fields) {
+  auto left = ParsePrimary(fields);
+  if (!left) {
+    return nullptr;
+  }
+  while (StartsPrimary(Peek())) {
+    // FTS5 never inserts an implicit AND next to a parenthesised group.
+    if (Peek().type == QueryTokenType::LPAREN || left->grouped) {
+      error = "fts5 query requires an operator next to a parenthesised group";
+      return nullptr;
+    }
+    auto right = ParsePrimary(fields);
+    if (!right) {
+      return nullptr;
+    }
+    if (left->type == QueryNodeType::GROUP_AND && !left->grouped) {
+      left->children.push_back(std::move(right));
+    } else {
+      auto group = make_uniq<QueryNode>();
+      group->type = QueryNodeType::GROUP_AND;
+      group->children.push_back(std::move(left));
+      group->children.push_back(std::move(right));
+      left = std::move(group);
+    }
+  }
+  return left;
+}
+
+unique_ptr<QueryNode> QueryParser::ParsePrimary(const vector<string> &fields) {
+  auto &token = Peek();
+  if (token.type == QueryTokenType::MINUS) {
+    error = "fts5 column complements are not supported";
+    return nullptr;
+  }
+  if (token.type == QueryTokenType::CARET) {
+    error = "fts5 initial-token anchors are not supported";
+    return nullptr;
+  }
+  if (token.type == QueryTokenType::LBRACE) {
+    Next();
+    vector<string> names;
+    while (Peek().type == QueryTokenType::BAREWORD) {
+      names.push_back(Next().text);
+    }
+    if (Peek().type != QueryTokenType::RBRACE || names.empty()) {
+      error = "fts5 column list is invalid";
+      return nullptr;
+    }
+    Next();
+    if (Peek().type != QueryTokenType::COLON) {
+      error = "fts5 column list must be followed by a colon";
+      return nullptr;
+    }
+    Next();
+    vector<string> narrowed;
+    for (auto &name : names) {
+      if (fields.empty() ||
+          std::find(fields.begin(), fields.end(), name) != fields.end()) {
+        narrowed.push_back(name);
+      }
+    }
+    if (narrowed.empty()) {
+      error = "fts5 column filters select no common column";
+      return nullptr;
+    }
+    if (++depth > MAX_QUERY_DEPTH) {
+      error = "fts5 query is nested too deeply";
+      return nullptr;
+    }
+    auto inner = ParsePrimary(narrowed);
+    depth--;
+    return inner;
+  }
+  if (token.type == QueryTokenType::BAREWORD &&
+      Peek(1).type == QueryTokenType::COLON) {
+    auto name = Next().text;
+    Next();
+    vector<string> narrowed;
+    if (fields.empty() ||
+        std::find(fields.begin(), fields.end(), name) != fields.end()) {
+      narrowed.push_back(name);
+    }
+    if (narrowed.empty()) {
+      error = "fts5 column filters select no common column";
+      return nullptr;
+    }
+    if (++depth > MAX_QUERY_DEPTH) {
+      error = "fts5 query is nested too deeply";
+      return nullptr;
+    }
+    auto inner = ParsePrimary(narrowed);
+    depth--;
+    return inner;
+  }
+  if (token.type == QueryTokenType::LPAREN) {
+    Next();
+    if (++depth > MAX_QUERY_DEPTH) {
+      error = "fts5 query is nested too deeply";
+      return nullptr;
+    }
+    auto inner = ParseOr(fields);
+    depth--;
+    if (!inner) {
+      return nullptr;
+    }
+    if (Peek().type != QueryTokenType::RPAREN) {
+      error = "fts5 query contains an unclosed parenthesis";
+      return nullptr;
+    }
+    Next();
+    inner->grouped = true;
+    return inner;
+  }
+  if (token.type == QueryTokenType::BAREWORD && token.text == "NEAR" &&
+      Peek(1).type == QueryTokenType::LPAREN) {
+    return ParseNear(fields);
+  }
+  if (token.type == QueryTokenType::BAREWORD ||
+      token.type == QueryTokenType::STRING) {
+    return ParsePhrase(fields);
+  }
+  error = "fts5 query has a dangling operator";
+  return nullptr;
+}
+
+unique_ptr<QueryNode> QueryParser::ParseNear(const vector<string> &fields) {
+  Next();
+  Next();
+  vector<string> terms;
+  while (Peek().type == QueryTokenType::BAREWORD) {
+    terms.push_back(Next().text);
+    if (Peek().type == QueryTokenType::STAR) {
+      error = "fts5 prefixes inside NEAR are not supported";
+      return nullptr;
+    }
+  }
+  if (Peek().type == QueryTokenType::STRING) {
+    error = "fts5 phrases inside NEAR are not supported";
+    return nullptr;
+  }
+  if (terms.size() < 2) {
+    error = "fts5 NEAR requires two or more terms";
+    return nullptr;
+  }
+  string near_distance;
+  if (Peek().type == QueryTokenType::COMMA) {
+    Next();
+    auto &number = Peek();
+    if (number.type != QueryTokenType::BAREWORD ||
+        number.text.find_first_not_of("0123456789") != string::npos) {
+      error = "fts5 NEAR distance must be a non-negative integer";
+      return nullptr;
+    }
+    // Re-serialized through an integer: raw digits like 007 are invalid JSON.
+    uint64_t distance = 0;
+    auto maximum = static_cast<uint64_t>(NumericLimits<int64_t>::Maximum());
+    for (auto c : number.text) {
+      auto digit = static_cast<uint64_t>(c - '0');
+      if (distance > (maximum - digit) / 10) {
+        error = "fts5 NEAR distance is out of range";
+        return nullptr;
+      }
+      distance = distance * 10 + digit;
+    }
+    Next();
+    near_distance = to_string(distance);
+  }
+  if (Peek().type != QueryTokenType::RPAREN) {
+    error = "fts5 NEAR group is unclosed";
+    return nullptr;
+  }
+  Next();
+  auto leaf = make_uniq<QueryNode>();
+  leaf->query = StringUtil::Join(terms, " ");
+  leaf->query_mode = "near";
+  leaf->near_distance = near_distance;
+  leaf->fields = fields;
+  return leaf;
+}
+
+unique_ptr<QueryNode> QueryParser::ParsePhrase(const vector<string> &fields) {
+  vector<string> parts;
+  auto quoted = false;
+  auto prefix = false;
+  while (true) {
+    auto &token = Peek();
+    if (token.type == QueryTokenType::BAREWORD) {
+      parts.push_back(Next().text);
+    } else if (token.type == QueryTokenType::STRING) {
+      quoted = true;
+      parts.push_back(Next().text);
+    } else {
+      error = "fts5 query has a dangling operator";
+      return nullptr;
+    }
+    if (Peek().type == QueryTokenType::STAR) {
+      Next();
+      prefix = true;
+      break;
+    }
+    if (Peek().type != QueryTokenType::PLUS) {
+      break;
+    }
+    Next();
+  }
+  // FTS5 lets "" concatenate as a no-op, so empty segments drop out.
+  vector<string> words;
+  for (auto &part : parts) {
+    if (!part.empty()) {
+      words.push_back(part);
+    }
+  }
+  auto leaf = make_uniq<QueryNode>();
+  leaf->query = StringUtil::Join(words, " ");
+  leaf->fields = fields;
+  auto multiple_tokens = quoted || words.size() > 1;
+  if (prefix) {
+    leaf->query_mode = multiple_tokens ? "phrase_prefix" : "autocomplete";
+  } else if (multiple_tokens) {
+    leaf->query_mode = "phrase";
+  }
+  return leaf;
+}
+
+// FTS5 treats an empty phrase as adding no constraint: it drops out of AND, OR
+// and NOT groups, while a query left with no constraint at all matches nothing.
+static unique_ptr<QueryNode> PruneNeutralNodes(unique_ptr<QueryNode> node) {
+  if (node->type == QueryNodeType::LEAF) {
+    return node->query.empty() ? nullptr : std::move(node);
+  }
+  if (node->type == QueryNodeType::GROUP_NOT) {
+    auto must = PruneNeutralNodes(std::move(node->children[0]));
+    auto must_not = PruneNeutralNodes(std::move(node->children[1]));
+    if (!must) {
+      // NOT without a positive side matches nothing, like a bare empty phrase.
+      auto empty = make_uniq<QueryNode>();
+      empty->query_mode = "phrase";
+      return empty;
+    }
+    if (!must_not) {
+      return must;
+    }
+    node->children[0] = std::move(must);
+    node->children[1] = std::move(must_not);
+    return node;
+  }
+  vector<unique_ptr<QueryNode>> kept;
+  for (auto &child : node->children) {
+    auto pruned = PruneNeutralNodes(std::move(child));
+    if (pruned) {
+      kept.push_back(std::move(pruned));
+    }
+  }
+  if (kept.empty()) {
+    return nullptr;
+  }
+  if (kept.size() == 1) {
+    return std::move(kept[0]);
+  }
+  node->children = std::move(kept);
+  return node;
+}
+
+static void SerializeNode(const QueryNode &node, string &result) {
+  result += "{";
+  if (node.type == QueryNodeType::LEAF) {
+    result += "\"query\":\"" + EscapeJSON(node.query) + "\"";
+    if (!node.query_mode.empty()) {
+      result += ",\"query_mode\":\"" + node.query_mode + "\"";
+    }
+    if (!node.near_distance.empty()) {
+      result += ",\"near_distance\":" + node.near_distance;
+    }
+    if (!node.fields.empty()) {
+      result += ",\"fields\":[";
+      for (idx_t i = 0; i < node.fields.size(); i++) {
+        if (i > 0) {
+          result += ",";
+        }
+        result += "\"" + EscapeJSON(node.fields[i]) + "\"";
+      }
+      result += "]";
+    }
+  } else if (node.type == QueryNodeType::GROUP_NOT) {
+    result += "\"must\":[";
+    SerializeNode(*node.children[0], result);
+    result += "],\"must_not\":[";
+    SerializeNode(*node.children[1], result);
+    result += "]";
+  } else {
+    result +=
+        node.type == QueryNodeType::GROUP_AND ? "\"must\":[" : "\"should\":[";
+    for (idx_t i = 0; i < node.children.size(); i++) {
+      if (i > 0) {
+        result += ",";
+      }
+      SerializeNode(*node.children[i], result);
+    }
+    result += "]";
+  }
+  result += "}";
+}
+
+static string ParseQuery(const string &input, string &query_json) {
+  vector<QueryToken> tokens;
+  auto lex_error = Lex(input, tokens);
+  if (!lex_error.empty()) {
+    return lex_error;
+  }
+  if (tokens.size() == 1) {
+    return "fts5 query is empty";
+  }
+  QueryParser parser(tokens);
+  auto root = parser.ParseOr(vector<string>());
+  if (!root) {
+    return parser.error.empty() ? "fts5 query is invalid" : parser.error;
+  }
+  if (parser.Peek().type != QueryTokenType::END) {
+    return parser.error.empty() ? "fts5 query has trailing input"
+                                : parser.error;
+  }
+  root = PruneNeutralNodes(std::move(root));
+  if (!root) {
+    root = make_uniq<QueryNode>();
+    root->query_mode = "phrase";
+  }
+  SerializeNode(*root, query_json);
+  return string();
+}
+
+} // namespace
+
+static void ParseQueryFunction(DataChunk &args, ExpressionState &state,
+                               Vector &result) {
+  auto inputs = args.data[0].Values<string_t>();
+
+  result.SetVectorType(VectorType::FLAT_VECTOR);
+  FlatVector::ValidityMutable(result).SetAllValid(args.size());
+  auto &children = StructVector::GetEntries(result);
+  auto json_writer = FlatVector::Writer<string_t>(children[0], args.size());
+  auto error_writer = FlatVector::Writer<string_t>(children[1], args.size());
+
+  for (idx_t i = 0; i < args.size(); i++) {
+    auto input = inputs[i];
+    string query_json;
+    string error;
+    if (!input.IsValid()) {
+      error = "fts5 query must not be NULL";
+    } else {
+      error = ParseQuery(input.GetValue().GetString(), query_json);
+    }
+    if (error.empty()) {
+      json_writer.WriteValue(query_json);
+      error_writer.WriteNull();
+    } else {
+      json_writer.WriteNull();
+      error_writer.WriteValue(error);
+    }
+  }
+}
+
+ScalarFunction GetFTSParseQueryFunction() {
+  auto return_type =
+      LogicalType::STRUCT({{"query_json", LogicalType::VARCHAR},
+                           {"error_message", LogicalType::VARCHAR}});
+  ScalarFunction function("fts_parse_query", {LogicalType::VARCHAR},
+                          return_type, ParseQueryFunction);
+  function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+  return function;
+}
+
+} // namespace duckdb

--- a/src/include/fts_query_parser.hpp
+++ b/src/include/fts_query_parser.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "duckdb/function/scalar_function.hpp"
+
+namespace duckdb {
+
+ScalarFunction GetFTSParseQueryFunction();
+
+} // namespace duckdb

--- a/test/sql/fts/test_fts5_query_syntax.test
+++ b/test/sql/fts/test_fts5_query_syntax.test
@@ -1,0 +1,334 @@
+# name: test/sql/fts/test_fts5_query_syntax.test
+# description: FTS5 query strings compile to the structured queries the layered index executes
+# group: [fts]
+
+require skip_reload
+
+require fts
+
+require json
+
+require no_alternative_verify
+
+# Compilation: one assertion per construct, plus the precedence cases.
+query I
+SELECT fts_parse_query('alpha').query_json
+----
+{"query":"alpha"}
+
+query I
+SELECT fts_parse_query('alpha beta').query_json
+----
+{"must":[{"query":"alpha"},{"query":"beta"}]}
+
+query I
+SELECT fts_parse_query('alpha AND beta').query_json
+----
+{"must":[{"query":"alpha"},{"query":"beta"}]}
+
+query I
+SELECT fts_parse_query('alpha OR beta gamma').query_json
+----
+{"should":[{"query":"alpha"},{"must":[{"query":"beta"},{"query":"gamma"}]}]}
+
+query I
+SELECT fts_parse_query('alpha NOT beta gamma').query_json
+----
+{"must":[{"query":"alpha"}],"must_not":[{"must":[{"query":"beta"},{"query":"gamma"}]}]}
+
+query I
+SELECT fts_parse_query('alpha OR beta NOT gamma').query_json
+----
+{"should":[{"query":"alpha"},{"must":[{"query":"beta"}],"must_not":[{"query":"gamma"}]}]}
+
+query I
+SELECT fts_parse_query('(alpha OR beta) NOT gamma').query_json
+----
+{"must":[{"should":[{"query":"alpha"},{"query":"beta"}]}],"must_not":[{"query":"gamma"}]}
+
+query I
+SELECT fts_parse_query('"machine learning"').query_json
+----
+{"query":"machine learning","query_mode":"phrase"}
+
+query I
+SELECT fts_parse_query('"machine learning" + theory').query_json
+----
+{"query":"machine learning theory","query_mode":"phrase"}
+
+query I
+SELECT fts_parse_query('mach*').query_json
+----
+{"query":"mach","query_mode":"autocomplete"}
+
+query I
+SELECT fts_parse_query('"machine lear" + ni*').query_json
+----
+{"query":"machine lear ni","query_mode":"phrase_prefix"}
+
+query I
+SELECT fts_parse_query('body : alpha').query_json
+----
+{"query":"alpha","fields":["body"]}
+
+query I
+SELECT fts_parse_query('{title body} : (alpha OR beta)').query_json
+----
+{"should":[{"query":"alpha","fields":["title","body"]},{"query":"beta","fields":["title","body"]}]}
+
+query I
+SELECT fts_parse_query('NEAR(machine learning, 5)').query_json
+----
+{"query":"machine learning","query_mode":"near","near_distance":5}
+
+query I
+SELECT fts_parse_query('NEAR(machine learning)').query_json
+----
+{"query":"machine learning","query_mode":"near"}
+
+# Lowercase and/or/not are ordinary barewords (FTS5 keywords are capital letters).
+query I
+SELECT fts_parse_query('and or not').query_json
+----
+{"must":[{"query":"and"},{"query":"or"},{"query":"not"}]}
+
+query I
+SELECT fts_parse_query('"a ""quoted"" b"').query_json
+----
+{"query":"a \"quoted\" b","query_mode":"phrase"}
+
+# Inside quotes, * and ^ are literal characters handed to the analyzer.
+query I
+SELECT fts_parse_query('"a*b^c"').query_json
+----
+{"query":"a*b^c","query_mode":"phrase"}
+
+# Bare terms concatenate like single-token phrases.
+query I
+SELECT fts_parse_query('a + b').query_json
+----
+{"query":"a b","query_mode":"phrase"}
+
+query I
+SELECT fts_parse_query('"abc" *').query_json
+----
+{"query":"abc","query_mode":"phrase_prefix"}
+
+# NOT is left-associative.
+query I
+SELECT fts_parse_query('a NOT b NOT c').query_json
+----
+{"must":[{"must":[{"query":"a"}],"must_not":[{"query":"b"}]}],"must_not":[{"query":"c"}]}
+
+# NEAR without a parenthesis is an ordinary term, exactly as in FTS5.
+query I
+SELECT fts_parse_query('NEAR alpha').query_json
+----
+{"must":[{"query":"NEAR"},{"query":"alpha"}]}
+
+# The distance is re-serialized through an integer, so 007 stays valid JSON.
+query I
+SELECT fts_parse_query('NEAR(a b, 007)').query_json
+----
+{"query":"a b","query_mode":"near","near_distance":7}
+
+# Control characters inside quotes come out as JSON escapes.
+query I
+SELECT fts_parse_query('"a' || chr(9) || 'b"').query_json
+----
+{"query":"a\tb","query_mode":"phrase"}
+
+query I
+SELECT fts_parse_query('"a' || chr(1) || 'b"').query_json
+----
+{"query":"a\u0001b","query_mode":"phrase"}
+
+# An empty phrase adds no constraint (FTS5 semantics): it drops out of groups,
+# and a query left with no constraint at all matches nothing.
+query I
+SELECT fts_parse_query('""').query_json
+----
+{"query":"","query_mode":"phrase"}
+
+query I
+SELECT fts_parse_query('"" alpha').query_json
+----
+{"query":"alpha"}
+
+query I
+SELECT fts_parse_query('alpha NOT ""').query_json
+----
+{"query":"alpha"}
+
+query I
+SELECT fts_parse_query('"" NOT alpha').query_json
+----
+{"query":"","query_mode":"phrase"}
+
+query I
+SELECT fts_parse_query('"" + alpha').query_json
+----
+{"query":"alpha","query_mode":"phrase"}
+
+# Rejection: every unsupported or malformed construct names itself.
+query I
+SELECT fts_parse_query('one (two OR three)').error_message
+----
+fts5 query requires an operator next to a parenthesised group
+
+query I
+SELECT fts_parse_query('NEAR("a b" c, 3)').error_message
+----
+fts5 phrases inside NEAR are not supported
+
+query I
+SELECT fts_parse_query('^alpha').error_message
+----
+fts5 initial-token anchors are not supported
+
+query I
+SELECT fts_parse_query('-title : alpha').error_message
+----
+fts5 column complements are not supported
+
+query I
+SELECT fts_parse_query('NEAR(alpha, 3)').error_message
+----
+fts5 NEAR requires two or more terms
+
+query I
+SELECT fts_parse_query('alpha AND').error_message
+----
+fts5 query has a dangling operator
+
+query I
+SELECT fts_parse_query('(alpha').error_message
+----
+fts5 query contains an unclosed parenthesis
+
+query I
+SELECT fts_parse_query('"alpha').error_message
+----
+fts5 query contains an unclosed string
+
+query I
+SELECT fts_parse_query('NEAR(alpha beta, x)').error_message
+----
+fts5 NEAR distance must be a non-negative integer
+
+query I
+SELECT fts_parse_query('   ').error_message
+----
+fts5 query is empty
+
+query I
+SELECT fts_parse_query('!@#').error_message
+----
+fts5 query contains a character that requires quoting
+
+query I
+SELECT fts_parse_query('title : (body : alpha)').error_message
+----
+fts5 column filters select no common column
+
+query I
+SELECT fts_parse_query('{title').error_message
+----
+fts5 column list is invalid
+
+query I
+SELECT fts_parse_query('{title body} alpha').error_message
+----
+fts5 column list must be followed by a colon
+
+# Lowercase near is a bareword, which makes the parenthesis the error.
+query I
+SELECT fts_parse_query('near(alpha beta, 3)').error_message
+----
+fts5 query requires an operator next to a parenthesised group
+
+query I
+SELECT fts_parse_query('NEAR(a b, 99999999999999999999)').error_message
+----
+fts5 NEAR distance is out of range
+
+# Nesting is bounded like FTS5's own parser (it names a maximum depth of 256).
+query I
+SELECT fts_parse_query(repeat('(', 300) || 'alpha' || repeat(')', 300)).error_message
+----
+fts5 query is nested too deeply
+
+query I
+SELECT fts_parse_query(repeat('alpha NOT ', 300) || 'alpha').error_message
+----
+fts5 query is nested too deeply
+
+query I
+SELECT fts_parse_query(NULL).error_message
+----
+fts5 query must not be NULL
+
+# The two struct members are complementary.
+query II
+SELECT fts_parse_query('alpha').error_message IS NULL, fts_parse_query('(alpha').query_json IS NULL
+----
+true	true
+
+# Equivalence: parse, execute, and match the hand-written structured query.
+statement ok
+CREATE TABLE fts5_docs(id VARCHAR NOT NULL, title VARCHAR, body VARCHAR)
+
+statement ok
+INSERT INTO fts5_docs VALUES
+    ('py_ml',    'python guide',  'python and machine learning basics'),
+    ('py_only',  'python intro',  'python scripting deprecated tricks'),
+    ('java_doc', 'java handbook', 'java patterns explained'),
+    ('duck_t',   'duck title',    'no water here'),
+    ('duck_b',   'plain title',   'a duck in the body')
+
+statement ok
+PRAGMA create_fts_index('fts5_docs', 'id', 'title', 'body', stemmer='none', stopwords='none', layered_search=true)
+
+query I
+SELECT (
+    SELECT list(docname ORDER BY docname)
+    FROM fts_main_fts5_docs.search_layered_bm25_query(fts_parse_query('python AND "machine learning"').query_json::JSON)
+) = (
+    SELECT list(docname ORDER BY docname)
+    FROM fts_main_fts5_docs.search_layered_bm25_query('{"must":[{"query":"python"},{"query":"machine learning","query_mode":"phrase"}]}')
+)
+----
+true
+
+query I
+SELECT (
+    SELECT list(docname ORDER BY docname)
+    FROM fts_main_fts5_docs.search_layered_bm25_query(fts_parse_query('python OR java NOT deprecated').query_json::JSON)
+) = (
+    SELECT list(docname ORDER BY docname)
+    FROM fts_main_fts5_docs.search_layered_bm25_query('{"should":[{"query":"python"},{"must":[{"query":"java"}],"must_not":[{"query":"deprecated"}]}]}')
+)
+----
+true
+
+query I
+SELECT (
+    SELECT list(docname ORDER BY docname)
+    FROM fts_main_fts5_docs.search_layered_bm25_query(fts_parse_query('NEAR(machine learning, 5)').query_json::JSON)
+) = (
+    SELECT list(docname ORDER BY docname)
+    FROM fts_main_fts5_docs.search_layered_bm25('machine learning', query_mode := 'near', near_distance := 5)
+)
+----
+true
+
+query I
+SELECT (
+    SELECT list(docname ORDER BY docname)
+    FROM fts_main_fts5_docs.search_layered_bm25_query(fts_parse_query('title : duck').query_json::JSON)
+) = (
+    SELECT list(docname ORDER BY docname)
+    FROM fts_main_fts5_docs.search_layered_bm25('duck', fields := 'title')
+)
+----
+true


### PR DESCRIPTION
The structured Boolean macros execute JSON query trees, but issue #17 originally asked for FTS5's query-string syntax, and it is the only item on that list still open. I offered an implementation there and am following up on it here.

I added a scalar function, fts_parse_query, that compiles an FTS5 query string into the JSON the structured macros already validate and execute. It covers implicit and explicit AND, OR, binary NOT, parentheses, quoted phrases with "" escaping and + concatenation, trailing * prefixes, col : and {col1 col2} : filters, and NEAR(a b, N), whose N maps to near_distance one to one. It is a compiler rather than an engine: there is no new execution path, the index format and the search macros are untouched, and field names are checked by the existing query-time validation.

Where the FTS5 documentation leaves room, I measured SQLite itself and matched it: keywords are recognized in capital letters only, an empty phrase adds no constraint, NEAR distances are re-serialized through an integer, and nesting is bounded at depth 256, the limit FTS5's own error message names. Initial-token anchors (^), column complements (-col :), and phrases inside NEAR are rejected with named errors rather than misparsed.

The tests compile each construct and the precedence cases to exact JSON, assert every rejection message, and check equivalence through the executor against hand-written structured queries. The README documents the function with examples, and the parser benchmarks mirror the analyzer set across bare-term, Boolean, phrase, and NEAR strings.