### PR TITLE
Add highlight and snippet functions to layered search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(FTS_SQL_ASSETS
     "ENGLISH_STOPWORDS|src/sql/index/english_stopwords.sql"
     "IMPORT_STOPWORDS|src/sql/index/import_stopwords.sql"
     "TOKENIZE_MACRO|src/sql/index/tokenize_macro.sql"
+    "TOKENIZE_SPANS_MACRO|src/sql/index/tokenize_spans_macro.sql"
     "ANALYZE_TOKEN_STREAM|src/sql/index/analyze_token_stream.sql"
     "ANALYZE_TEXT_MACRO|src/sql/index/analyze_text_macro.sql"
     "INDEX_TABLES|src/sql/index/index_tables.sql"
@@ -79,6 +80,7 @@ set(EXTENSION_SOURCES
     ${EXTENSION_BASE_FOLDER}/fts_near.cpp
     ${EXTENSION_BASE_FOLDER}/fts_pattern.cpp
     ${EXTENSION_BASE_FOLDER}/fts_sql_template.cpp
+    ${EXTENSION_BASE_FOLDER}/fts_tokenize_spans.cpp
     ${EXTENSION_BASE_FOLDER}/fts_unicode_classifier.cpp
     ${FTS_SQL_ASSETS_SOURCE}
     ${SNOWBALL_BASE_FOLDER}/libstemmer/libstemmer.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(FTS_SQL_ASSETS
     "IMPORT_STOPWORDS|src/sql/index/import_stopwords.sql"
     "TOKENIZE_MACRO|src/sql/index/tokenize_macro.sql"
     "TOKENIZE_SPANS_MACRO|src/sql/index/tokenize_spans_macro.sql"
+    "HIGHLIGHT_MACROS|src/sql/index/highlight_macros.sql"
     "ANALYZE_TOKEN_STREAM|src/sql/index/analyze_token_stream.sql"
     "ANALYZE_TEXT_MACRO|src/sql/index/analyze_text_macro.sql"
     "INDEX_TABLES|src/sql/index/index_tables.sql"
@@ -79,6 +80,7 @@ set(EXTENSION_SOURCES
     ${EXTENSION_BASE_FOLDER}/fts_indexing.cpp
     ${EXTENSION_BASE_FOLDER}/fts_near.cpp
     ${EXTENSION_BASE_FOLDER}/fts_pattern.cpp
+    ${EXTENSION_BASE_FOLDER}/fts_highlight.cpp
     ${EXTENSION_BASE_FOLDER}/fts_sql_template.cpp
     ${EXTENSION_BASE_FOLDER}/fts_tokenize_spans.cpp
     ${EXTENSION_BASE_FOLDER}/fts_unicode_classifier.cpp

--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ removed before positions are assigned. Stopwords are removed afterward, so
 leading and internal stopwords remain visible as position gaps.
 
 Current analyzers use a position length of one and the token type `word`.
-Offsets are reserved as nullable, half-open, zero-based UTF-8 byte offsets into
-the original input. They are currently `NULL` because normalization prevents
-the regex and OpenSearch-compatible tokenizers from mapping every token
-reliably back to the original string.
+Offsets are half-open, zero-based UTF-8 byte offsets into the original input.
+Normalization is tracked codepoint by codepoint, so a token's offsets address
+the original bytes even when accent stripping or lowercasing changes the byte
+width. Offsets cover whole original codepoints.
 
 `analyze_text` uses the same generated analyzer definition as bulk indexing,
 incremental maintenance, and query analysis. The lower-level list-returning

--- a/README.md
+++ b/README.md
@@ -107,6 +107,38 @@ incremental maintenance, and query analysis. The lower-level list-returning
 stopword removal or stemming. Analyzer contract changes are versioned in
 `index_metadata` and require dropping and recreating an existing index.
 
+### `highlight` and `snippet` Functions
+
+```python
+highlight(s, query_string, before, after, query_mode := 'standard')
+
+snippet(s, query_string, before, after, ellipsis, max_tokens,
+        query_mode := 'standard')
+```
+
+Each index schema also contains these two scalar macros, following SQLite
+FTS5's `highlight` and `snippet`. `highlight` wraps every matched token of
+`s` between `before` and `after`, in the original text: case, punctuation,
+and byte widths are preserved through the analyzer's offsets. `snippet`
+renders the `max_tokens`-token window centered on the first match, marking
+truncated edges with `ellipsis`.
+
+A token matches when its analyzed term equals an analyzed query term, so
+stemming applies: on a porter index, `machine` also marks `machines`.
+Dictionary expansions (prefix, substring, fuzzy) are not marked. In `phrase`
+and `phrase_prefix` modes a whole phrase occurrence is wrapped as one span,
+and overlapping spans merge. In `near` mode every matched term is marked,
+without the distance constraint. Wildcard and regex modes are not supported.
+Unmatched text is returned unchanged.
+
+```sql
+SELECT fts_main_documents.highlight(body, 'quack', '<b>', '</b>')
+FROM documents;
+
+SELECT fts_main_documents.snippet(body, 'quack', '[', ']', '...', 8)
+FROM documents;
+```
+
 ### `match_bm25` Function
 
 ```python

--- a/src/fts_config.py
+++ b/src/fts_config.py
@@ -19,6 +19,7 @@ source_files = [
     for x in [
         'extension/fts/fts_extension.cpp',
         'extension/fts/fts_indexing.cpp',
+        'extension/fts/fts_highlight.cpp',
         'extension/fts/fts_pattern.cpp',
         'extension/fts/fts_tokenize_spans.cpp',
         'extension/fts/fts_unicode_classifier.cpp',

--- a/src/fts_config.py
+++ b/src/fts_config.py
@@ -20,6 +20,7 @@ source_files = [
         'extension/fts/fts_extension.cpp',
         'extension/fts/fts_indexing.cpp',
         'extension/fts/fts_pattern.cpp',
+        'extension/fts/fts_tokenize_spans.cpp',
         'extension/fts/fts_unicode_classifier.cpp',
     ]
 ]

--- a/src/fts_extension.cpp
+++ b/src/fts_extension.cpp
@@ -13,126 +13,13 @@
 #include "fts_indexing.hpp"
 #include "fts_near.hpp"
 #include "fts_pattern.hpp"
+#include "fts_opensearch_tokenizer.hpp"
+#include "fts_tokenize_spans.hpp"
 #include "fts_unicode_classifier.hpp"
 #include "libstemmer.h"
 #include "utf8proc_wrapper.hpp"
 
 namespace duckdb {
-
-static bool IsOpenSearchStandardSingleTokenScript(FTSUnicodeScript script) {
-  return script == FTSUnicodeScript::HAN ||
-         script == FTSUnicodeScript::HIRAGANA;
-}
-
-static bool IsOpenSearchStandardIntraTokenPunctuation(int32_t codepoint) {
-  return codepoint == '\'' || codepoint == 0x2019 || codepoint == '.' ||
-         codepoint == '_';
-}
-
-static bool IsJapaneseProlongedSoundMark(int32_t codepoint) {
-  return codepoint == 0x30FC || codepoint == 0xFF70;
-}
-
-static bool
-IsOpenSearchStandardTokenChar(int32_t codepoint,
-                              const FTSUnicodeProperties &properties) {
-  if (properties.whitespace || properties.punctuation) {
-    return false;
-  }
-  return properties.alphabetic || properties.decimal_number ||
-         properties.script == FTSUnicodeScript::KATAKANA ||
-         IsJapaneseProlongedSoundMark(codepoint);
-}
-
-static bool
-IsOpenSearchStandardContinuationChar(int32_t codepoint,
-                                     const FTSUnicodeProperties &properties) {
-  return !IsOpenSearchStandardSingleTokenScript(properties.script) &&
-         !properties.emoji &&
-         (IsOpenSearchStandardTokenChar(codepoint, properties) ||
-          properties.combining_mark);
-}
-
-template <class LIST_WRITER>
-static void TokenizeOpenSearchStandard(string_t input, LIST_WRITER &list) {
-  auto input_data = input.GetData();
-  auto input_size = input.GetSize();
-  idx_t token_start = 0;
-  idx_t token_size = 0;
-
-  auto flush_token = [&]() {
-    if (token_size == 0) {
-      return;
-    }
-    list.WriteElement().WriteStringRef(string_t(
-        input_data + token_start, UnsafeNumericCast<uint32_t>(token_size)));
-    token_size = 0;
-  };
-
-  auto decode_codepoint = [&](idx_t pos, int32_t &codepoint, int &char_size,
-                              FTSUnicodeProperties &properties) -> bool {
-    if (pos >= input_size) {
-      return false;
-    }
-    char_size = 0;
-    codepoint = Utf8Proc::UTF8ToCodepoint(input_data + pos, char_size,
-                                          input_size - pos);
-    if (char_size <= 0) {
-      return false;
-    }
-    properties = FTSUnicodeClassifier::Classify(codepoint);
-    return true;
-  };
-
-  for (idx_t pos = 0; pos < input_size;) {
-    int char_size = 0;
-    int32_t codepoint = 0;
-    FTSUnicodeProperties properties{};
-    if (!decode_codepoint(pos, codepoint, char_size, properties)) {
-      flush_token();
-      pos++;
-      continue;
-    }
-
-    // Proper OpenSearch parity should delegate word boundary detection to
-    // Lucene's StandardTokenizer or ICU UBRK_WORD. DuckDB's bundled ICU build
-    // currently disables break iteration, so this scanner keeps the known
-    // OpenSearch-compatible cases local. Combining marks are continuations to
-    // preserve decomposed accents such as "cafe\u0301" rather than splitting or
-    // dropping the mark.
-    if (properties.combining_mark && token_size > 0) {
-      token_size += UnsafeNumericCast<idx_t>(char_size);
-    } else if (IsOpenSearchStandardSingleTokenScript(properties.script) ||
-               properties.emoji) {
-      flush_token();
-      list.WriteElement().WriteStringRef(
-          string_t(input_data + pos, UnsafeNumericCast<uint32_t>(char_size)));
-    } else if (IsOpenSearchStandardIntraTokenPunctuation(codepoint) &&
-               token_size > 0) {
-      int32_t next_codepoint = 0;
-      int next_char_size = 0;
-      FTSUnicodeProperties next_properties{};
-      auto next_pos = pos + UnsafeNumericCast<idx_t>(char_size);
-      if (decode_codepoint(next_pos, next_codepoint, next_char_size,
-                           next_properties) &&
-          IsOpenSearchStandardContinuationChar(next_codepoint,
-                                               next_properties)) {
-        token_size += UnsafeNumericCast<idx_t>(char_size);
-      } else {
-        flush_token();
-      }
-    } else if (IsOpenSearchStandardTokenChar(codepoint, properties)) {
-      if (token_size == 0) {
-        token_start = pos;
-      }
-      token_size += UnsafeNumericCast<idx_t>(char_size);
-    } else {
-      flush_token();
-    }
-    pos += UnsafeNumericCast<idx_t>(char_size);
-  }
-  flush_token();
-}
 
 static void OpenSearchStandardTokenizeFunction(DataChunk &args,
                                                ExpressionState &state,
@@ -151,7 +38,13 @@ static void OpenSearchStandardTokenizeFunction(DataChunk &args,
       continue;
     }
     auto list = list_writer.WriteDynamicList();
-    TokenizeOpenSearchStandard(input_entry.GetValue(), list);
+    auto input_value = input_entry.GetValue();
+    ScanOpenSearchStandardTokens(input_value.GetData(), input_value.GetSize(),
+                                 [&](idx_t start, idx_t size) {
+                                   list.WriteElement().WriteStringRef(string_t(
+                                       input_value.GetData() + start,
+                                       UnsafeNumericCast<uint32_t>(size)));
+                                 });
   }
 
   StringVector::AddHeapReference(ListVector::GetChildMutable(result),
@@ -234,6 +127,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 
   loader.RegisterFunction(stem_func);
   loader.RegisterFunction(opensearch_standard_tokenize_func);
+  loader.RegisterFunction(GetFTSTokenizeSpansFunction());
   loader.RegisterFunction(GetFTSAnalyzePatternFunction());
   loader.RegisterFunction(GetFTSNearTfFunction());
   loader.RegisterFunction(create_fts_index_func);

--- a/src/fts_extension.cpp
+++ b/src/fts_extension.cpp
@@ -13,6 +13,7 @@
 #include "fts_indexing.hpp"
 #include "fts_near.hpp"
 #include "fts_pattern.hpp"
+#include "fts_highlight.hpp"
 #include "fts_opensearch_tokenizer.hpp"
 #include "fts_tokenize_spans.hpp"
 #include "fts_unicode_classifier.hpp"
@@ -127,6 +128,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 
   loader.RegisterFunction(stem_func);
   loader.RegisterFunction(opensearch_standard_tokenize_func);
+  loader.RegisterFunction(GetFTSRenderHighlightFunction());
   loader.RegisterFunction(GetFTSTokenizeSpansFunction());
   loader.RegisterFunction(GetFTSAnalyzePatternFunction());
   loader.RegisterFunction(GetFTSNearTfFunction());

--- a/src/fts_highlight.cpp
+++ b/src/fts_highlight.cpp
@@ -1,0 +1,122 @@
+#include "fts_highlight.hpp"
+
+#include "duckdb/common/vector/flat_vector.hpp"
+#include "duckdb/common/vector/list_vector.hpp"
+#include "duckdb/common/vector/string_vector.hpp"
+#include "duckdb/common/vector/vector_writer.hpp"
+
+#include <algorithm>
+
+namespace duckdb {
+
+namespace {
+
+struct HighlightSpan {
+  uint32_t start;
+  uint32_t end;
+};
+
+// Overlapping or touching spans render as one, the way FTS5 merges a phrase
+// with a term inside it or with an overlapping phrase.
+static void MergeSpans(vector<HighlightSpan> &spans) {
+  std::sort(spans.begin(), spans.end(),
+            [](const HighlightSpan &a, const HighlightSpan &b) {
+              return a.start < b.start || (a.start == b.start && a.end < b.end);
+            });
+  idx_t merged = 0;
+  for (idx_t i = 0; i < spans.size(); i++) {
+    if (merged > 0 && spans[i].start <= spans[merged - 1].end) {
+      spans[merged - 1].end = MaxValue(spans[merged - 1].end, spans[i].end);
+    } else {
+      spans[merged++] = spans[i];
+    }
+  }
+  spans.resize(merged);
+}
+
+} // namespace
+
+static void RenderHighlightFunction(DataChunk &args, ExpressionState &state,
+                                    Vector &result) {
+  auto texts = args.data[0].Values<string_t>();
+  auto start_lists = args.data[1].Values<VectorListType<uint32_t>>();
+  auto end_lists = args.data[2].Values<VectorListType<uint32_t>>();
+  auto befores = args.data[3].Values<string_t>();
+  auto afters = args.data[4].Values<string_t>();
+  auto window_froms = args.data[5].Values<uint32_t>();
+  auto window_tos = args.data[6].Values<uint32_t>();
+  auto leadings = args.data[7].Values<bool>();
+  auto trailings = args.data[8].Values<bool>();
+  auto ellipses = args.data[9].Values<string_t>();
+
+  auto writer = FlatVector::Writer<string_t>(result, args.size());
+  for (idx_t i = 0; i < args.size(); i++) {
+    if (!texts[i].IsValid() || !start_lists[i].IsValid() ||
+        !end_lists[i].IsValid() || !befores[i].IsValid() ||
+        !afters[i].IsValid() || !window_froms[i].IsValid() ||
+        !window_tos[i].IsValid() || !leadings[i].IsValid() ||
+        !trailings[i].IsValid() || !ellipses[i].IsValid()) {
+      writer.WriteNull();
+      continue;
+    }
+    auto text = texts[i].GetValue();
+    auto window_from = window_froms[i].GetValue();
+    auto window_to = MinValue(window_tos[i].GetValue(),
+                              UnsafeNumericCast<uint32_t>(text.GetSize()));
+    window_from = MinValue(window_from, window_to);
+
+    vector<uint32_t> span_starts;
+    vector<uint32_t> span_ends;
+    span_starts.reserve(start_lists[i].GetListLength());
+    span_ends.reserve(end_lists[i].GetListLength());
+    for (const auto value : start_lists[i].GetChildValues()) {
+      span_starts.push_back(value.IsValid() ? value.GetValue() : window_to);
+    }
+    for (const auto value : end_lists[i].GetChildValues()) {
+      span_ends.push_back(value.IsValid() ? value.GetValue() : window_from);
+    }
+    vector<HighlightSpan> spans;
+    auto span_count = MinValue<idx_t>(span_starts.size(), span_ends.size());
+    for (idx_t j = 0; j < span_count; j++) {
+      auto span_start = MaxValue(span_starts[j], window_from);
+      auto span_end = MinValue(span_ends[j], window_to);
+      if (span_start < span_end) {
+        spans.push_back({span_start, span_end});
+      }
+    }
+    MergeSpans(spans);
+
+    auto data = text.GetData();
+    string rendered;
+    if (leadings[i].GetValue()) {
+      rendered += ellipses[i].GetValue().GetString();
+    }
+    auto cursor = window_from;
+    for (auto &span : spans) {
+      rendered.append(data + cursor, span.start - cursor);
+      rendered += befores[i].GetValue().GetString();
+      rendered.append(data + span.start, span.end - span.start);
+      rendered += afters[i].GetValue().GetString();
+      cursor = span.end;
+    }
+    rendered.append(data + cursor, window_to - cursor);
+    if (trailings[i].GetValue()) {
+      rendered += ellipses[i].GetValue().GetString();
+    }
+    writer.WriteValue(rendered);
+  }
+}
+
+ScalarFunction GetFTSRenderHighlightFunction() {
+  ScalarFunction function(
+      "fts_render_highlight",
+      {LogicalType::VARCHAR, LogicalType::LIST(LogicalType::UINTEGER),
+       LogicalType::LIST(LogicalType::UINTEGER), LogicalType::VARCHAR,
+       LogicalType::VARCHAR, LogicalType::UINTEGER, LogicalType::UINTEGER,
+       LogicalType::BOOLEAN, LogicalType::BOOLEAN, LogicalType::VARCHAR},
+      LogicalType::VARCHAR, RenderHighlightFunction);
+  function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+  return function;
+}
+
+} // namespace duckdb

--- a/src/fts_index_builder.cpp
+++ b/src/fts_index_builder.cpp
@@ -103,6 +103,11 @@ static string TokenizeSpansMacroScript(const QualifiedName &qname,
        {"lower", SQLTemplateArgument::Boolean(lower)}});
 }
 
+static string HighlightMacrosScript(const QualifiedName &qname) {
+  return RenderSQLTemplate(fts_sql::HIGHLIGHT_MACROS,
+                           {{"fts_schema", GetFTSSchemaArgument(qname)}});
+}
+
 static string AnalyzeTextMacroScript(const QualifiedName &qname,
                                      const FTSAnalyzerConfig &config) {
   return RenderSQLTemplate(
@@ -425,6 +430,7 @@ string FTSIndexBuilder::Create(const FTSIndexConfig &config,
   result += TokenizeSpansMacroScript(qname, config.tokenizer, config.ignore,
                                      config.strip_accents, config.lower);
   result += AnalyzeTextMacroScript(qname, analyzer_config);
+  result += HighlightMacrosScript(qname);
   result += IndexTablesScript(
       qname, config.input_id, config.input_values, GetFTSBuildTermsTable(qname),
       GetFTSBuildDictTable(qname), GetFTSBuildRawDictTable(qname),

--- a/src/fts_index_builder.cpp
+++ b/src/fts_index_builder.cpp
@@ -90,6 +90,19 @@ static string TokenizeMacroScript(const QualifiedName &qname,
        {"token_expression", SQLTemplateArgument::TrustedSQL(expr)}});
 }
 
+static string TokenizeSpansMacroScript(const QualifiedName &qname,
+                                       const string &tokenizer,
+                                       const string &ignore, bool strip_accents,
+                                       bool lower) {
+  return RenderSQLTemplate(
+      fts_sql::TOKENIZE_SPANS_MACRO,
+      {{"fts_schema", GetFTSSchemaArgument(qname)},
+       {"tokenizer", SQLTemplateArgument::StringLiteral(tokenizer)},
+       {"ignore", SQLTemplateArgument::StringLiteral(ignore)},
+       {"strip_accents", SQLTemplateArgument::Boolean(strip_accents)},
+       {"lower", SQLTemplateArgument::Boolean(lower)}});
+}
+
 static string AnalyzeTextMacroScript(const QualifiedName &qname,
                                      const FTSAnalyzerConfig &config) {
   return RenderSQLTemplate(
@@ -97,7 +110,7 @@ static string AnalyzeTextMacroScript(const QualifiedName &qname,
       {{"fts_schema", GetFTSSchemaArgument(qname)},
        {"analyzed_tokens",
         SQLTemplateArgument::TrustedSQL(RenderAnalyzeTokenStream(
-            qname, config, AnalyzeTokenStreamProjection::POSITION))}});
+            qname, config, AnalyzeTokenStreamProjection::POSITION_OFFSETS))}});
 }
 
 static string IndexTablesScript(const QualifiedName &qname,
@@ -409,6 +422,8 @@ string FTSIndexBuilder::Create(const FTSIndexConfig &config,
   result += StopwordsScript(config);
   result += TokenizeMacroScript(qname, config.tokenizer, config.ignore,
                                 config.strip_accents, config.lower);
+  result += TokenizeSpansMacroScript(qname, config.tokenizer, config.ignore,
+                                     config.strip_accents, config.lower);
   result += AnalyzeTextMacroScript(qname, analyzer_config);
   result += IndexTablesScript(
       qname, config.input_id, config.input_values, GetFTSBuildTermsTable(qname),

--- a/src/fts_index_common.cpp
+++ b/src/fts_index_common.cpp
@@ -52,6 +52,9 @@ AnalyzeTokenStreamProjectionSQL(AnalyzeTokenStreamProjection projection) {
     return "";
   case AnalyzeTokenStreamProjection::POSITION:
     return ",\n       tokenized.position";
+  case AnalyzeTokenStreamProjection::POSITION_OFFSETS:
+    return ",\n       tokenized.position,\n       tokenized.start_offset,\n"
+           "       tokenized.end_offset";
   case AnalyzeTokenStreamProjection::DOCID_FIELDID:
     return ",\n       tokenized.docid,\n       tokenized.fieldid";
   case AnalyzeTokenStreamProjection::DOCID_FIELDID_POSITION:

--- a/src/fts_tokenize_spans.cpp
+++ b/src/fts_tokenize_spans.cpp
@@ -1,0 +1,312 @@
+#include "fts_tokenize_spans.hpp"
+
+#include "duckdb/common/vector/flat_vector.hpp"
+#include "duckdb/common/vector/list_vector.hpp"
+#include "duckdb/common/vector/string_vector.hpp"
+#include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/common/vector/vector_writer.hpp"
+#include "fts_opensearch_tokenizer.hpp"
+#include "re2/re2.h"
+#include "utf8proc.hpp"
+#include "utf8proc_wrapper.hpp"
+
+namespace duckdb {
+
+namespace {
+
+// One entry per run of original bytes that normalize one-to-one, or per
+// original codepoint whose normalization changes the byte width.
+struct NormalizedPiece {
+  uint32_t norm_start;
+  uint32_t norm_size;
+  uint32_t orig_start;
+  uint32_t orig_size;
+};
+
+struct NormalizedText {
+  string text;
+  vector<NormalizedPiece> pieces;
+};
+
+static void AppendLowered(const string &piece, string &result) {
+  idx_t pos = 0;
+  while (pos < piece.size()) {
+    int char_size = 0;
+    auto codepoint = Utf8Proc::UTF8ToCodepoint(piece.data() + pos, char_size,
+                                               piece.size() - pos);
+    if (char_size <= 0) {
+      result += piece[pos];
+      pos++;
+      continue;
+    }
+    auto lowered = Utf8Proc::CodepointToLower(codepoint);
+    char encoded[4];
+    int encoded_size = 0;
+    if (Utf8Proc::CodepointToUtf8(lowered, encoded_size, encoded)) {
+      result.append(encoded, UnsafeNumericCast<idx_t>(encoded_size));
+    } else {
+      result.append(piece.data() + pos, UnsafeNumericCast<idx_t>(char_size));
+    }
+    pos += UnsafeNumericCast<idx_t>(char_size);
+  }
+}
+
+// Normalizes codepoint by codepoint with the same utf8proc calls the SQL
+// builtins use, recording which original bytes produced which normalized ones.
+static NormalizedText NormalizeWithMap(const char *data, idx_t size,
+                                       bool strip_accents, bool lower) {
+  NormalizedText result;
+  result.text.reserve(size);
+  idx_t pos = 0;
+  while (pos < size) {
+    auto lead = data[pos];
+    if (!(lead & 0x80)) {
+      // ASCII: accent stripping is a no-op and lowercasing is one branch,
+      // both one-to-one, so consecutive bytes extend one identity run.
+      auto c = lower && lead >= 'A' && lead <= 'Z'
+                   ? UnsafeNumericCast<char>(lead + 32)
+                   : lead;
+      if (!result.pieces.empty()) {
+        auto &run = result.pieces.back();
+        if (run.norm_size == run.orig_size &&
+            run.norm_start + run.norm_size == result.text.size() &&
+            run.orig_start + run.orig_size == pos) {
+          run.norm_size++;
+          run.orig_size++;
+          result.text += c;
+          pos++;
+          continue;
+        }
+      }
+      result.pieces.push_back({UnsafeNumericCast<uint32_t>(result.text.size()),
+                               1, UnsafeNumericCast<uint32_t>(pos), 1});
+      result.text += c;
+      pos++;
+      continue;
+    }
+    int char_size = 0;
+    auto codepoint =
+        Utf8Proc::UTF8ToCodepoint(data + pos, char_size, size - pos);
+    if (char_size <= 0) {
+      char_size = 1;
+      codepoint = -1;
+    }
+    string piece(data + pos, UnsafeNumericCast<idx_t>(char_size));
+    if (codepoint >= 0) {
+      if (strip_accents) {
+        auto stripped = utf8proc_remove_accents(
+            reinterpret_cast<const utf8proc_uint8_t *>(piece.c_str()),
+            UnsafeNumericCast<utf8proc_ssize_t>(piece.size()));
+        if (stripped) {
+          piece = const_char_ptr_cast(stripped);
+          free(stripped);
+        }
+      }
+      if (lower && !piece.empty()) {
+        string lowered;
+        AppendLowered(piece, lowered);
+        piece = std::move(lowered);
+      }
+    }
+    if (!piece.empty()) {
+      result.pieces.push_back({UnsafeNumericCast<uint32_t>(result.text.size()),
+                               UnsafeNumericCast<uint32_t>(piece.size()),
+                               UnsafeNumericCast<uint32_t>(pos),
+                               UnsafeNumericCast<uint32_t>(char_size)});
+      result.text += piece;
+    }
+    pos += UnsafeNumericCast<idx_t>(char_size);
+  }
+  return result;
+}
+
+static const NormalizedPiece *PieceContaining(const NormalizedText &normalized,
+                                              uint32_t norm_position) {
+  auto it = std::upper_bound(normalized.pieces.begin(), normalized.pieces.end(),
+                             norm_position,
+                             [](uint32_t value, const NormalizedPiece &piece) {
+                               return value < piece.norm_start;
+                             });
+  if (it == normalized.pieces.begin()) {
+    return nullptr;
+  }
+  return &*(it - 1);
+}
+
+struct TokenSpan {
+  uint32_t norm_start;
+  uint32_t norm_size;
+};
+
+static bool IsUtf8CharacterStart(char c) { return (c & 0xC0) != 0x80; }
+
+// Compiled once per distinct delimiter: the pattern is constant per query.
+struct CachedRegex {
+  string delimiter;
+  unique_ptr<duckdb_re2::RE2> regex;
+
+  duckdb_re2::RE2 &Get(const string &pattern) {
+    if (!regex || delimiter != pattern) {
+      duckdb_re2::StringPiece pattern_piece(pattern);
+      regex = make_uniq<duckdb_re2::RE2>(pattern_piece);
+      if (!regex->ok()) {
+        throw InvalidInputException(regex->error());
+      }
+      delimiter = pattern;
+    }
+    return *regex;
+  }
+};
+
+// Mirrors StringSplitter::Split in DuckDB's string_split.cpp, spans included.
+static void SplitRegexWithSpans(const string &text, duckdb_re2::RE2 &regex,
+                                vector<TokenSpan> &spans) {
+  auto base = text.data();
+  auto input_data = base;
+  auto input_size = UnsafeNumericCast<idx_t>(text.size());
+  while (input_size > 0) {
+    duckdb_re2::StringPiece match;
+    if (!regex.Match(duckdb_re2::StringPiece(input_data, input_size), 0,
+                     input_size, duckdb_re2::RE2::UNANCHORED, &match, 1)) {
+      break;
+    }
+    auto match_size = UnsafeNumericCast<idx_t>(match.size());
+    auto pos = UnsafeNumericCast<idx_t>(match.data() - input_data);
+    if (match_size == 0 && pos == 0) {
+      for (pos++; pos < input_size; pos++) {
+        if (IsUtf8CharacterStart(input_data[pos])) {
+          break;
+        }
+      }
+      if (pos == input_size) {
+        break;
+      }
+    }
+    spans.push_back({UnsafeNumericCast<uint32_t>(input_data - base),
+                     UnsafeNumericCast<uint32_t>(pos)});
+    input_data += pos + match_size;
+    input_size -= pos + match_size;
+  }
+  spans.push_back({UnsafeNumericCast<uint32_t>(input_data - base),
+                   UnsafeNumericCast<uint32_t>(input_size)});
+}
+
+struct MappedToken {
+  uint32_t norm_start;
+  uint32_t norm_size;
+  uint32_t orig_start;
+  uint32_t orig_end;
+};
+
+static uint32_t MapWithinPiece(const NormalizedPiece &piece,
+                               uint32_t norm_position) {
+  // Inside a one-to-one run the mapping is exact; a width-changing codepoint
+  // rounds to its original start.
+  if (piece.norm_size == piece.orig_size) {
+    return piece.orig_start + (norm_position - piece.norm_start);
+  }
+  return piece.orig_start;
+}
+
+static MappedToken MapSpan(const NormalizedText &normalized, idx_t orig_size,
+                           TokenSpan span) {
+  MappedToken token{span.norm_start, span.norm_size, 0, 0};
+  if (span.norm_size == 0) {
+    auto piece = span.norm_start < normalized.text.size()
+                     ? PieceContaining(normalized, span.norm_start)
+                     : nullptr;
+    auto boundary = piece ? MapWithinPiece(*piece, span.norm_start)
+                          : UnsafeNumericCast<uint32_t>(orig_size);
+    token.orig_start = boundary;
+    token.orig_end = boundary;
+    return token;
+  }
+  auto first = PieceContaining(normalized, span.norm_start);
+  auto last = PieceContaining(normalized, span.norm_start + span.norm_size - 1);
+  D_ASSERT(first && last);
+  token.orig_start = MapWithinPiece(*first, span.norm_start);
+  token.orig_end = last->norm_size == last->orig_size
+                       ? last->orig_start + (span.norm_start + span.norm_size -
+                                             last->norm_start)
+                       : last->orig_start + last->orig_size;
+  return token;
+}
+
+} // namespace
+
+static void TokenizeSpansFunction(DataChunk &args, ExpressionState &state,
+                                  Vector &result) {
+  auto inputs = args.data[0].Values<string_t>();
+  auto tokenizers = args.data[1].Values<string_t>();
+  auto ignores = args.data[2].Values<string_t>();
+  auto strip_flags = args.data[3].Values<bool>();
+  auto lower_flags = args.data[4].Values<bool>();
+
+  result.SetVectorType(VectorType::FLAT_VECTOR);
+  auto list_entries = FlatVector::GetDataMutable<list_entry_t>(result);
+  auto &list_validity = FlatVector::ValidityMutable(result);
+
+  CachedRegex cached_regex;
+  idx_t total = 0;
+  for (idx_t i = 0; i < args.size(); i++) {
+    auto input = inputs[i];
+    if (!input.IsValid() || !tokenizers[i].IsValid() || !ignores[i].IsValid() ||
+        !strip_flags[i].IsValid() || !lower_flags[i].IsValid()) {
+      list_validity.SetInvalid(i);
+      list_entries[i].offset = 0;
+      list_entries[i].length = 0;
+      continue;
+    }
+    auto input_value = input.GetValue();
+    auto normalized =
+        NormalizeWithMap(input_value.GetData(), input_value.GetSize(),
+                         strip_flags[i].GetValue(), lower_flags[i].GetValue());
+
+    vector<TokenSpan> spans;
+    if (tokenizers[i].GetValue().GetString() == "opensearch_standard") {
+      ScanOpenSearchStandardTokens(
+          normalized.text.data(), normalized.text.size(),
+          [&](idx_t start, idx_t size) {
+            spans.push_back({UnsafeNumericCast<uint32_t>(start),
+                             UnsafeNumericCast<uint32_t>(size)});
+          });
+    } else {
+      auto delimiter = "(" + ignores[i].GetValue().GetString() + ")|\\s+";
+      SplitRegexWithSpans(normalized.text, cached_regex.Get(delimiter), spans);
+    }
+
+    list_entries[i].offset = total;
+    list_entries[i].length = spans.size();
+    ListVector::Reserve(result, total + spans.size());
+    auto &child = ListVector::GetEntry(result);
+    auto &members = StructVector::GetEntries(child);
+    auto raw_terms = FlatVector::GetDataMutable<string_t>(members[0]);
+    auto start_offsets = FlatVector::GetDataMutable<uint32_t>(members[1]);
+    auto end_offsets = FlatVector::GetDataMutable<uint32_t>(members[2]);
+    for (auto &span : spans) {
+      auto mapped = MapSpan(normalized, input_value.GetSize(), span);
+      raw_terms[total] = StringVector::AddString(
+          members[0], normalized.text.data() + mapped.norm_start,
+          mapped.norm_size);
+      start_offsets[total] = mapped.orig_start;
+      end_offsets[total] = mapped.orig_end;
+      total++;
+    }
+  }
+  ListVector::SetListSize(result, total);
+}
+
+ScalarFunction GetFTSTokenizeSpansFunction() {
+  auto span_type = LogicalType::STRUCT({{"raw_term", LogicalType::VARCHAR},
+                                        {"start_offset", LogicalType::UINTEGER},
+                                        {"end_offset", LogicalType::UINTEGER}});
+  ScalarFunction function("fts_tokenize_spans",
+                          {LogicalType::VARCHAR, LogicalType::VARCHAR,
+                           LogicalType::VARCHAR, LogicalType::BOOLEAN,
+                           LogicalType::BOOLEAN},
+                          LogicalType::LIST(span_type), TokenizeSpansFunction);
+  function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+  return function;
+}
+
+} // namespace duckdb

--- a/src/include/fts_highlight.hpp
+++ b/src/include/fts_highlight.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "duckdb/function/scalar_function.hpp"
+
+namespace duckdb {
+
+ScalarFunction GetFTSRenderHighlightFunction();
+
+} // namespace duckdb

--- a/src/include/fts_index_common.hpp
+++ b/src/include/fts_index_common.hpp
@@ -14,6 +14,7 @@ struct FTSAnalyzerConfig {
 enum class AnalyzeTokenStreamProjection : uint8_t {
   NONE,
   POSITION,
+  POSITION_OFFSETS,
   DOCID_FIELDID,
   DOCID_FIELDID_POSITION,
   TOKEN_POSITION

--- a/src/include/fts_opensearch_tokenizer.hpp
+++ b/src/include/fts_opensearch_tokenizer.hpp
@@ -1,0 +1,120 @@
+#pragma once
+
+#include "fts_unicode_classifier.hpp"
+#include "utf8proc_wrapper.hpp"
+
+namespace duckdb {
+
+inline bool IsOpenSearchStandardSingleTokenScript(FTSUnicodeScript script) {
+  return script == FTSUnicodeScript::HAN ||
+         script == FTSUnicodeScript::HIRAGANA;
+}
+
+inline bool IsOpenSearchStandardIntraTokenPunctuation(int32_t codepoint) {
+  return codepoint == '\'' || codepoint == 0x2019 || codepoint == '.' ||
+         codepoint == '_';
+}
+
+inline bool IsJapaneseProlongedSoundMark(int32_t codepoint) {
+  return codepoint == 0x30FC || codepoint == 0xFF70;
+}
+
+inline bool
+IsOpenSearchStandardTokenChar(int32_t codepoint,
+                              const FTSUnicodeProperties &properties) {
+  if (properties.whitespace || properties.punctuation) {
+    return false;
+  }
+  return properties.alphabetic || properties.decimal_number ||
+         properties.script == FTSUnicodeScript::KATAKANA ||
+         IsJapaneseProlongedSoundMark(codepoint);
+}
+
+inline bool
+IsOpenSearchStandardContinuationChar(int32_t codepoint,
+                                     const FTSUnicodeProperties &properties) {
+  return !IsOpenSearchStandardSingleTokenScript(properties.script) &&
+         !properties.emoji &&
+         (IsOpenSearchStandardTokenChar(codepoint, properties) ||
+          properties.combining_mark);
+}
+
+template <class EMIT>
+void ScanOpenSearchStandardTokens(const char *input_data, idx_t input_size,
+                                  EMIT &&emit) {
+  idx_t token_start = 0;
+  idx_t token_size = 0;
+
+  auto flush_token = [&]() {
+    if (token_size == 0) {
+      return;
+    }
+    emit(token_start, token_size);
+    token_size = 0;
+  };
+
+  auto decode_codepoint = [&](idx_t pos, int32_t &codepoint, int &char_size,
+                              FTSUnicodeProperties &properties) -> bool {
+    if (pos >= input_size) {
+      return false;
+    }
+    char_size = 0;
+    codepoint = Utf8Proc::UTF8ToCodepoint(input_data + pos, char_size,
+                                          input_size - pos);
+    if (char_size <= 0) {
+      return false;
+    }
+    properties = FTSUnicodeClassifier::Classify(codepoint);
+    return true;
+  };
+
+  for (idx_t pos = 0; pos < input_size;) {
+    int char_size = 0;
+    int32_t codepoint = 0;
+    FTSUnicodeProperties properties{};
+    if (!decode_codepoint(pos, codepoint, char_size, properties)) {
+      flush_token();
+      pos++;
+      continue;
+    }
+
+    // Proper OpenSearch parity should delegate word boundary detection to
+    // Lucene's StandardTokenizer or ICU UBRK_WORD. DuckDB's bundled ICU build
+    // currently disables break iteration, so this scanner keeps the known
+    // OpenSearch-compatible cases local. Combining marks are continuations to
+    // preserve decomposed accents such as "café" rather than splitting or
+    // dropping the mark.
+    if (properties.combining_mark && token_size > 0) {
+      token_size += UnsafeNumericCast<idx_t>(char_size);
+    } else if (IsOpenSearchStandardSingleTokenScript(properties.script) ||
+               properties.emoji) {
+      flush_token();
+      emit(pos, UnsafeNumericCast<idx_t>(char_size));
+    } else if (IsOpenSearchStandardIntraTokenPunctuation(codepoint) &&
+               token_size > 0) {
+      int32_t next_codepoint = 0;
+      int next_char_size = 0;
+      FTSUnicodeProperties next_properties{};
+      auto next_pos = pos + UnsafeNumericCast<idx_t>(char_size);
+      if (decode_codepoint(next_pos, next_codepoint, next_char_size,
+                           next_properties) &&
+          IsOpenSearchStandardContinuationChar(next_codepoint,
+                                               next_properties)) {
+        token_size += UnsafeNumericCast<idx_t>(char_size);
+      } else {
+        flush_token();
+      }
+    } else if (IsOpenSearchStandardTokenChar(codepoint, properties)) {
+      if (token_size == 0) {
+        token_start = pos;
+      }
+      token_size += UnsafeNumericCast<idx_t>(char_size);
+    } else {
+      flush_token();
+    }
+    pos += UnsafeNumericCast<idx_t>(char_size);
+  }
+  flush_token();
+}
+
+} // namespace duckdb

--- a/src/include/fts_tokenize_spans.hpp
+++ b/src/include/fts_tokenize_spans.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "duckdb/function/scalar_function.hpp"
+
+namespace duckdb {
+
+ScalarFunction GetFTSTokenizeSpansFunction();
+
+} // namespace duckdb

--- a/src/sql/index/analyze_text_macro.sql
+++ b/src/sql/index/analyze_text_macro.sql
@@ -1,17 +1,26 @@
 CREATE MACRO {{fts_schema}}.analyze_text(s) AS TABLE
-WITH positioned_tokens AS (
-    SELECT token.raw_term,
+WITH fts_extension_autoload AS (
+    -- Bind DuckDB's stable FTS autoload entry before the internal analyzer.
+    SELECT stem('', 'none') AS marker
+),
+positioned_tokens AS (
+    SELECT token.t.raw_term AS raw_term,
+           token.t.start_offset AS start_offset,
+           token.t.end_offset AS end_offset,
            token.position::UINTEGER AS position
-    FROM UNNEST(
+    FROM fts_extension_autoload,
+         UNNEST(
         list_filter(
-            {{fts_schema}}.tokenize(s),
-            lambda value: value IS NOT NULL AND value <> ''
+            {{fts_schema}}.tokenize_spans(s),
+            lambda value: value.raw_term IS NOT NULL AND value.raw_term <> ''
         )
-    ) WITH ORDINALITY AS token(raw_term, position)
+    ) WITH ORDINALITY AS token(t, position)
 ),
 tokenized AS (
     SELECT raw_term,
-           position
+           position,
+           start_offset,
+           end_offset
     FROM positioned_tokens
 ),
 analyzed_tokens AS (
@@ -21,6 +30,8 @@ token_stream AS (
     SELECT raw_term,
            term,
            position,
+           start_offset,
+           end_offset,
            (
                position
                - coalesce(lag(position) OVER (ORDER BY position), 0)
@@ -32,7 +43,7 @@ SELECT raw_term,
        position,
        position_increment,
        1::UINTEGER AS position_length,
-       NULL::UINTEGER AS start_offset,
-       NULL::UINTEGER AS end_offset,
+       start_offset,
+       end_offset,
        'word'::VARCHAR AS token_type
 FROM token_stream;

--- a/src/sql/index/highlight_macros.sql
+++ b/src/sql/index/highlight_macros.sql
@@ -1,0 +1,151 @@
+CREATE MACRO {{fts_schema}}.__highlight_spans(s, query_string, query_mode) AS TABLE
+WITH fts_extension_autoload AS (
+    -- Bind DuckDB's stable FTS autoload entry before the internal analyzer.
+    SELECT stem('', 'none') AS marker
+),
+text_tokens AS (
+    SELECT raw_term,
+           term,
+           position,
+           start_offset,
+           end_offset
+    FROM fts_extension_autoload,
+         {{fts_schema}}.analyze_text(s)
+),
+query_tokens AS (
+    SELECT raw_term,
+           term,
+           row_number() OVER (ORDER BY position) AS query_index,
+           count(*) OVER () AS query_count
+    FROM {{fts_schema}}.analyze_text(query_string)
+)
+SELECT text_tokens.start_offset AS span_start,
+       text_tokens.end_offset AS span_end
+FROM text_tokens
+WHERE lower(query_mode::VARCHAR) IN ('standard', 'near')
+  AND text_tokens.term IN (SELECT query_tokens.term FROM query_tokens)
+UNION ALL
+SELECT text_tokens.start_offset,
+       text_tokens.end_offset
+FROM text_tokens
+JOIN query_tokens
+  ON (query_tokens.query_index < query_tokens.query_count AND text_tokens.term = query_tokens.term)
+  OR (query_tokens.query_index = query_tokens.query_count AND starts_with(text_tokens.raw_term, query_tokens.raw_term))
+WHERE lower(query_mode::VARCHAR) = 'autocomplete'
+UNION ALL
+SELECT anchors.start_offset,
+       max(members.end_offset)
+FROM text_tokens AS anchors
+JOIN text_tokens AS members
+  ON members.position >= anchors.position
+ AND members.position < anchors.position + (SELECT max(query_tokens.query_count) FROM query_tokens)
+JOIN query_tokens
+  ON query_tokens.query_index = members.position - anchors.position + 1
+ AND (
+     members.term = query_tokens.term
+     OR (
+         lower(query_mode::VARCHAR) = 'phrase_prefix'
+         AND query_tokens.query_index = query_tokens.query_count
+         AND starts_with(members.raw_term, query_tokens.raw_term)
+     )
+ )
+WHERE lower(query_mode::VARCHAR) IN ('phrase', 'phrase_prefix')
+GROUP BY anchors.position, anchors.start_offset
+HAVING count(*) = (SELECT max(query_tokens.query_count) FROM query_tokens);
+
+CREATE MACRO {{fts_schema}}.highlight(s, query_string, before, after, query_mode := 'standard') AS (
+    WITH matched_spans AS (
+        SELECT spans.span_start,
+               spans.span_end
+        FROM {{fts_schema}}.__highlight_spans(s, query_string, query_mode) AS spans
+    )
+    SELECT CASE
+        WHEN s IS NULL THEN NULL
+        WHEN lower(coalesce(query_mode::VARCHAR, '')) NOT IN ('standard', 'autocomplete', 'phrase', 'phrase_prefix', 'near')
+            THEN error('query_mode must be one of standard, autocomplete, phrase, phrase_prefix, or near')
+        ELSE fts_render_highlight(
+            s,
+            coalesce((SELECT list(matched_spans.span_start ORDER BY matched_spans.span_start, matched_spans.span_end) FROM matched_spans), []),
+            coalesce((SELECT list(matched_spans.span_end ORDER BY matched_spans.span_start, matched_spans.span_end) FROM matched_spans), []),
+            before,
+            after,
+            0,
+            strlen(s)::UINTEGER,
+            false,
+            false,
+            ''
+        )
+    END
+);
+
+CREATE MACRO {{fts_schema}}.snippet(s, query_string, before, after, ellipsis, max_tokens, query_mode := 'standard') AS (
+    WITH matched_spans AS (
+        SELECT spans.span_start,
+               spans.span_end
+        FROM {{fts_schema}}.__highlight_spans(s, query_string, query_mode) AS spans
+    ),
+    text_tokens AS (
+        SELECT start_offset,
+               end_offset,
+               row_number() OVER (ORDER BY position) AS token_index
+        FROM {{fts_schema}}.analyze_text(s)
+    ),
+    -- Clamped before any arithmetic so an absurd max_tokens cannot overflow.
+    window_size AS (
+        SELECT least(greatest(try_cast(max_tokens AS BIGINT), 1),
+                     greatest((SELECT count(*) FROM text_tokens), 1)) AS window_tokens
+    ),
+    -- The window centers the first matched token and clamps to the document.
+    window_start AS (
+        SELECT greatest(1, least(
+                   coalesce(
+                       (SELECT min(text_tokens.token_index)
+                        FROM text_tokens
+                        JOIN matched_spans ON text_tokens.start_offset = matched_spans.span_start),
+                       1
+                   ) - (window_size.window_tokens - 1) // 2,
+                   (SELECT count(*) FROM text_tokens) - window_size.window_tokens + 1
+               )) AS window_index
+        FROM window_size
+    ),
+    -- An edge that cuts no token extends to the text boundary, so leading
+    -- whitespace and trailing punctuation survive an untruncated side.
+    window_bounds AS (
+        SELECT CASE
+                   WHEN window_start.window_index > 1
+                       THEN (SELECT min(text_tokens.start_offset) FROM text_tokens WHERE text_tokens.token_index >= window_start.window_index)
+                   ELSE 0
+               END AS window_from,
+               CASE
+                   WHEN (SELECT count(*) FROM text_tokens) >= window_start.window_index + window_size.window_tokens
+                       THEN (SELECT max(text_tokens.end_offset) FROM text_tokens WHERE text_tokens.token_index < window_start.window_index + window_size.window_tokens)
+                   ELSE strlen(s)::UINTEGER
+               END AS window_to,
+               window_start.window_index > 1 AS leading_cut,
+               (SELECT count(*) FROM text_tokens) >= window_start.window_index + window_size.window_tokens AS trailing_cut
+        FROM window_start, window_size
+    )
+    SELECT CASE
+        WHEN s IS NULL THEN NULL
+        WHEN lower(coalesce(query_mode::VARCHAR, '')) NOT IN ('standard', 'autocomplete', 'phrase', 'phrase_prefix', 'near')
+            THEN error('query_mode must be one of standard, autocomplete, phrase, phrase_prefix, or near')
+        WHEN try_cast(max_tokens AS HUGEINT) IS NULL
+             OR try_cast(max_tokens AS HUGEINT) < 1
+             OR try_cast(max_tokens AS HUGEINT) <> max_tokens
+             OR try_cast(max_tokens AS DOUBLE) <> floor(try_cast(max_tokens AS DOUBLE))
+            THEN error('max_tokens must be a positive integer')
+        WHEN (SELECT count(*) FROM text_tokens) = 0 THEN s
+        ELSE fts_render_highlight(
+            s,
+            coalesce((SELECT list(matched_spans.span_start ORDER BY matched_spans.span_start, matched_spans.span_end) FROM matched_spans), []),
+            coalesce((SELECT list(matched_spans.span_end ORDER BY matched_spans.span_start, matched_spans.span_end) FROM matched_spans), []),
+            before,
+            after,
+            (SELECT window_bounds.window_from FROM window_bounds),
+            (SELECT window_bounds.window_to FROM window_bounds),
+            (SELECT window_bounds.leading_cut FROM window_bounds),
+            (SELECT window_bounds.trailing_cut FROM window_bounds),
+            ellipsis
+        )
+    END
+);

--- a/src/sql/index/tokenize_spans_macro.sql
+++ b/src/sql/index/tokenize_spans_macro.sql
@@ -1,0 +1,1 @@
+CREATE MACRO {{fts_schema}}.tokenize_spans(s) AS fts_tokenize_spans(s, {{tokenizer}}, {{ignore}}, {{strip_accents}}, {{lower}});

--- a/test/sql/fts/test_analyze_offsets.test
+++ b/test/sql/fts/test_analyze_offsets.test
@@ -1,0 +1,205 @@
+# name: test/sql/fts/test_analyze_offsets.test
+# description: analyze_text returns byte offsets into the original string
+# group: [fts]
+
+require fts
+
+statement ok
+CREATE TABLE docs_regex(id VARCHAR NOT NULL, body VARCHAR)
+
+statement ok
+INSERT INTO docs_regex VALUES ('a', 'placeholder')
+
+statement ok
+PRAGMA create_fts_index('docs_regex', 'id', 'body', stemmer='none', stopwords='none')
+
+statement ok
+CREATE TABLE docs_os(id VARCHAR NOT NULL, body VARCHAR)
+
+statement ok
+INSERT INTO docs_os VALUES ('a', 'placeholder')
+
+statement ok
+PRAGMA create_fts_index('docs_os', 'id', 'body', tokenizer='opensearch_standard', stemmer='none', stopwords='none')
+
+statement ok
+CREATE TABLE docs_raw(id VARCHAR NOT NULL, body VARCHAR)
+
+statement ok
+INSERT INTO docs_raw VALUES ('a', 'placeholder')
+
+statement ok
+PRAGMA create_fts_index('docs_raw', 'id', 'body', stemmer='none', stopwords='none', strip_accents=0, lower=0)
+
+statement ok
+CREATE TABLE docs_lower(id VARCHAR NOT NULL, body VARCHAR)
+
+statement ok
+INSERT INTO docs_lower VALUES ('a', 'placeholder')
+
+statement ok
+PRAGMA create_fts_index('docs_lower', 'id', 'body', stemmer='none', stopwords='none', strip_accents=0, lower=1)
+
+statement ok
+CREATE TABLE docs_ignore(id VARCHAR NOT NULL, body VARCHAR)
+
+statement ok
+INSERT INTO docs_ignore VALUES ('a', 'placeholder')
+
+statement ok
+PRAGMA create_fts_index('docs_ignore', 'id', 'body', stemmer='none', stopwords='none', ignore='[0-9]+')
+
+# Offsets are half-open, zero-based UTF-8 byte offsets into the original input.
+query IIII
+SELECT raw_term, position, start_offset, end_offset
+FROM fts_main_docs_regex.analyze_text('Machine Learning')
+ORDER BY position
+----
+machine	1	0	7
+learning	2	8	16
+
+# Accented characters are wider in the original than after normalization.
+query IIII
+SELECT raw_term, position, start_offset, end_offset
+FROM fts_main_docs_regex.analyze_text('Café au lait')
+ORDER BY position
+----
+cafe	1	0	5
+au	2	6	8
+lait	3	9	13
+
+query IIII
+SELECT raw_term, position, start_offset, end_offset
+FROM fts_main_docs_regex.analyze_text('The MACHINE, learning')
+ORDER BY position
+----
+the	1	0	3
+machine	2	4	11
+learning	3	13	21
+
+# A combining mark stripped inside a token changes its byte width.
+query IIII
+SELECT raw_term, position, start_offset, end_offset
+FROM fts_main_docs_regex.analyze_text('e' || chr(769) || 'x abc')
+ORDER BY position
+----
+ex	1	0	4
+abc	2	5	8
+
+# Without normalization the offsets are the identity mapping.
+query IIII
+SELECT raw_term, position, start_offset, end_offset
+FROM fts_main_docs_raw.analyze_text('Café au lait')
+ORDER BY position
+----
+Café	1	0	5
+au	2	6	8
+lait	3	9	13
+
+# The OpenSearch-compatible tokenizer emits single-character Han tokens.
+query IIII
+SELECT raw_term, position, start_offset, end_offset
+FROM fts_main_docs_os.analyze_text('日本語 abc')
+ORDER BY position
+----
+日	1	0	3
+本	2	3	6
+語	3	6	9
+abc	4	10	13
+
+# Lowercasing alone can change the byte width: İ is two bytes, i is one.
+query IIII
+SELECT raw_term, position, start_offset, end_offset
+FROM fts_main_docs_lower.analyze_text('İstanbul calling')
+ORDER BY position
+----
+istanbul	1	0	9
+calling	2	10	17
+
+query IIII
+SELECT raw_term, position, start_offset, end_offset
+FROM fts_main_docs_ignore.analyze_text('abc123def x')
+ORDER BY position
+----
+abc	1	0	3
+def	2	6	9
+x	3	10	11
+
+query I
+SELECT fts_main_docs_regex.tokenize_spans(NULL) IS NULL
+----
+true
+
+# Normalization can change a character's Unicode class, so these four codepoints
+# tokenize differently if the text is split before it is normalized.
+query II
+SELECT list_transform(fts_main_docs_regex.tokenize_spans(s), lambda t: t.raw_term)
+       = fts_main_docs_regex.tokenize(s),
+       list_transform(fts_main_docs_regex.tokenize_spans(s), lambda t: [t.start_offset, t.end_offset])
+FROM (VALUES ('a' || chr(8622) || 'b'), ('a' || chr(9410) || 'b'), (chr(94192) || 'xy'), (chr(94193) || 'xy')) t(s)
+----
+true	[[0, 5]]
+true	[[0, 5]]
+true	[[4, 6]]
+true	[[4, 6]]
+
+# The span list carries the same tokens as tokenize, empties included.
+query I
+WITH battery(s) AS (
+    VALUES ('Café'), ('ß'), ('İstanbul'), ('ﬁle'), ('ΑΣ'), ('Σοφός'), ('ǅungla'),
+           ('а' || chr(769)), ('e' || chr(769)), ('ĲS'), ('Ⅷ'), ('㎡'),
+           ('a,,b'), (',lead'), ('trail,'), ('  spaced  out  '), ('')
+)
+SELECT count(*) FILTER (
+    WHERE list_transform(fts_main_docs_regex.tokenize_spans(s), lambda t: t.raw_term)
+          IS DISTINCT FROM fts_main_docs_regex.tokenize(s)
+)
+FROM battery
+----
+0
+
+query I
+WITH battery(s) AS (
+    VALUES ('Café'), ('İstanbul'), ('ΑΣ'), ('日本語 abc'), ('machine''s file'), ('')
+)
+SELECT count(*) FILTER (
+    WHERE list_transform(fts_main_docs_os.tokenize_spans(s), lambda t: t.raw_term)
+          IS DISTINCT FROM fts_main_docs_os.tokenize(s)
+)
+FROM battery
+----
+0
+
+query I
+WITH battery(s) AS (
+    VALUES ('Café au lait'), ('MIXED case'), ('a,,b'), ('')
+)
+SELECT count(*) FILTER (
+    WHERE list_transform(fts_main_docs_raw.tokenize_spans(s), lambda t: t.raw_term)
+          IS DISTINCT FROM fts_main_docs_raw.tokenize(s)
+)
+FROM battery
+----
+0
+
+query I
+WITH battery(s) AS (
+    VALUES ('abc123def'), ('123'), ('a1b2c3'), ('İstanbul 42 Café')
+)
+SELECT count(*) FILTER (
+    WHERE list_transform(fts_main_docs_ignore.tokenize_spans(s), lambda t: t.raw_term)
+          IS DISTINCT FROM fts_main_docs_ignore.tokenize(s)
+)
+FROM battery
+----
+0
+
+query I
+SELECT count(*)
+FROM fts_main_docs_regex.analyze_text('The MACHINE, learning Café')
+WHERE start_offset IS NULL OR end_offset IS NULL OR end_offset <= start_offset
+----
+0
+
+statement ok
+SELECT raw_term FROM fts_main_docs_regex.analyze_text(NULL)

--- a/test/sql/fts/test_analyze_offsets_persistence.test
+++ b/test/sql/fts/test_analyze_offsets_persistence.test
@@ -1,0 +1,40 @@
+# name: test/sql/fts/test_analyze_offsets_persistence.test
+# description: Persisted analyze_text autoloads FTS after restart
+# group: [fts]
+
+require fts
+
+require no_alternative_verify
+
+load {TEST_DIR}/analyze_offsets_persistence.db
+
+statement ok
+SET extension_directory='{TEST_DIR}/analyze_offsets_persistence_extensions'
+
+statement ok
+INSTALL '{BUILD_DIRECTORY}/extension/fts/fts.duckdb_extension'
+
+statement ok
+CREATE TABLE documents(id VARCHAR NOT NULL, body VARCHAR)
+
+statement ok
+INSERT INTO documents VALUES ('d1', 'Machine Learning')
+
+statement ok
+PRAGMA create_fts_index('documents', 'id', 'body', stemmer='none', stopwords='none')
+
+restart no_extension_load
+
+statement ok
+SET extension_directory='{TEST_DIR}/analyze_offsets_persistence_extensions'
+
+statement ok
+SET autoload_known_extensions=true
+
+query IIII
+SELECT raw_term, position, start_offset, end_offset
+FROM fts_main_documents.analyze_text('Machine Café')
+ORDER BY position
+----
+machine	1	0	7
+cafe	2	8	13

--- a/test/sql/fts/test_analyzer_contract.test
+++ b/test/sql/fts/test_analyzer_contract.test
@@ -66,12 +66,12 @@ ORDER BY id,
          source_field DESC,
          position
 ----
-1	title	running	run	2	2	1	NULL	NULL	word
-1	title	cafe	cafe	3	1	1	NULL	NULL	word
-1	title	foxes	fox	4	1	1	NULL	NULL	word
-1	body	alpha	alpha	1	1	1	NULL	NULL	word
-1	body	beta	beta	3	2	1	NULL	NULL	word
-2	title	runner	runner	2	2	1	NULL	NULL	word
+1	title	running	run	2	2	1	4	11	word
+1	title	cafe	cafe	3	1	1	15	20	word
+1	title	foxes	fox	4	1	1	21	26	word
+1	body	alpha	alpha	1	1	1	0	5	word
+1	body	beta	beta	3	2	1	10	14	word
+2	title	runner	runner	2	2	1	2	8	word
 
 # Every invocation has an independent position-increment window.
 query IIII

--- a/test/sql/fts/test_highlight_snippet.test
+++ b/test/sql/fts/test_highlight_snippet.test
@@ -1,0 +1,137 @@
+# name: test/sql/fts/test_highlight_snippet.test
+# description: highlight and snippet wrap matched tokens in the original text
+# group: [fts]
+
+require fts
+
+statement ok
+CREATE TABLE hl_docs(id VARCHAR NOT NULL, body VARCHAR)
+
+statement ok
+INSERT INTO hl_docs VALUES ('a', 'placeholder')
+
+statement ok
+PRAGMA create_fts_index('hl_docs', 'id', 'body', stemmer='porter', stopwords='none')
+
+query I
+SELECT fts_main_hl_docs.highlight('The MACHINE, learning fast', 'machine', '[', ']')
+----
+The [MACHINE], learning fast
+
+# Stemming applies: machine also marks machines, unlike unstemmed FTS5.
+query I
+SELECT fts_main_hl_docs.highlight('The MACHINE, learning fast; machines learn.', 'machine', '[', ']')
+----
+The [MACHINE], learning fast; [machines] learn.
+
+query I
+SELECT fts_main_hl_docs.highlight('The MACHINE, learning fast', 'machine learning', '[', ']', query_mode := 'phrase')
+----
+The [MACHINE, learning] fast
+
+query I
+SELECT fts_main_hl_docs.highlight('aa aa aa bb', 'aa aa', '[', ']', query_mode := 'phrase')
+----
+[aa aa aa] bb
+
+query I
+SELECT fts_main_hl_docs.highlight('The MACHINE, learning fast; machines learn.', 'mach', '[', ']', query_mode := 'autocomplete')
+----
+The [MACHINE], learning fast; [machines] learn.
+
+# Near mode marks every matched term; participation is not restricted.
+query I
+SELECT fts_main_hl_docs.highlight('The MACHINE, learning fast', 'machine fast', '[', ']', query_mode := 'near')
+----
+The [MACHINE], learning [fast]
+
+query I
+SELECT fts_main_hl_docs.highlight('machine learning', 'machine machine', '[', ']')
+----
+[machine] learning
+
+query I
+SELECT fts_main_hl_docs.highlight('nothing relevant here', 'absent', '<b>', '</b>')
+----
+nothing relevant here
+
+query I
+SELECT fts_main_hl_docs.highlight('The MACHINE is here', 'machine', '<b>', '</b>')
+----
+The <b>MACHINE</b> is here
+
+query I
+SELECT fts_main_hl_docs.highlight(NULL, 'machine', '[', ']') IS NULL
+----
+true
+
+query I
+SELECT fts_main_hl_docs.highlight('machine here', NULL, '[', ']')
+----
+machine here
+
+query I
+SELECT fts_main_hl_docs.highlight('Café und machine', 'cafe', '[', ']')
+----
+[Café] und machine
+
+statement ok
+CREATE TABLE hl_stop(id VARCHAR NOT NULL, body VARCHAR)
+
+statement ok
+INSERT INTO hl_stop VALUES ('a', 'placeholder')
+
+statement ok
+PRAGMA create_fts_index('hl_stop', 'id', 'body', stemmer='porter', stopwords='english')
+
+# An untruncated edge keeps everything around the kept tokens: stopwords,
+# leading whitespace, and trailing punctuation.
+query I
+SELECT fts_main_hl_stop.snippet('The MACHINE is here.', 'machine', '[', ']', '...', 64)
+----
+The [MACHINE] is here.
+
+query I
+SELECT fts_main_hl_stop.snippet('   machine leads', 'machine', '[', ']', '...', 64)
+----
+   [machine] leads
+
+query I
+SELECT fts_main_hl_stop.snippet('one machine two', 'machine', '[', ']', '...', 9223372036854775807)
+----
+one [machine] two
+
+query I
+SELECT fts_main_hl_docs.highlight('', 'machine', '[', ']')
+----
+(empty)
+
+statement error
+SELECT fts_main_hl_docs.snippet('machine', 'machine', '[', ']', '...', 0)
+----
+max_tokens must be a positive integer
+
+statement error
+SELECT fts_main_hl_docs.snippet('machine', 'machine', '[', ']', '...', 2.7)
+----
+max_tokens must be a positive integer
+
+query I
+SELECT fts_main_hl_docs.snippet('The MACHINE, learning fast; machines learn. Unrelated tail sentence here to make the document long', 'machine', '[', ']', '...', 6)
+----
+The [MACHINE], learning fast; [machines] learn...
+
+query I
+SELECT fts_main_hl_docs.snippet('The MACHINE is here', 'machine', '[', ']', '...', 64)
+----
+The [MACHINE] is here
+
+query I
+SELECT fts_main_hl_docs.snippet('completely unrelated column text that is long enough to need truncation somewhere around ten tokens', 'absent', '[', ']', '...', 5)
+----
+completely unrelated column text that...
+
+query I
+SELECT fts_main_hl_docs.snippet('one two three four five six seven machine nine ten', 'machine', '[', ']', '...', 3)
+----
+...seven [machine] nine...


### PR DESCRIPTION
Issue #1 asks for snippet and highlight functions like SQLite FTS5's, and it is the oldest open request in this repository. Nothing could mark matches until now because analyze_text reserved start_offset and end_offset but returned NULL: both tokenizers split the normalized string, and normalization changes byte widths.

The first commit fills those offsets. A new tokenizer normalizes codepoint by codepoint with the same utf8proc calls the SQL built-ins use, recording which original bytes produced which normalized ones, and then splits exactly as before, so the token stream is byte-identical to tokenize() and no existing index needs rebuilding. Offsets are computed at call time and never stored; the index format does not change. The analyzer inspection macro pays roughly 20 percent for this locally, and the search and indexing paths measure unchanged.

The second commit adds per-index highlight and snippet macros on top. I measured SQLite FTS5 first and matched it (fts5.html §5.1.2, §5.1.3): matches are wrapped in the original text with case and punctuation intact, a phrase wraps one span from its first token to its last, overlapping spans merge into one marker rather than nesting, the snippet window centers the first match and clamps to the document, max_tokens caps at 64, and an edge that cuts no token keeps the surrounding text. Three deltas are deliberate and documented in the README: stemming applies, so machine also marks machines; dictionary expansions are not marked; and near mode marks every matched term without the distance constraint.

The offset tests pin byte-exact positions for accents, combining marks, case folding that changes byte width, and CJK, plus a battery asserting the token stream equals tokenize() across index configurations, and a persistence test that restarts without the extension loaded. The highlight and snippet tests mirror the measured FTS5 cases and the boundary values.